### PR TITLE
Fix for older Emacs

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -752,7 +752,7 @@ number."
 
 (defun tide-read-new-symbol (old-symbol)
   (let ((new-symbol (read-from-minibuffer (format "Rename %s to " old-symbol))))
-    (if (string-blank-p new-symbol)
+    (if (string-match-p "\\`[ \t\n\r]*\\'" new-symbol)
         (error "Invalid name")
       new-symbol)))
 


### PR DESCRIPTION
string-blank-p was introduced at Emacs 24.4. And subr-x.el must be loaded.