### PR TITLE
Do not require tsconfig.json to start tide-server

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -97,7 +97,7 @@
   "Project root folder determined based on the presence of tsconfig.json."
   (or
    tide-project-root
-   (let ((root (locate-dominating-file default-directory "tsconfig.json")))
+   (let ((root (or (locate-dominating-file default-directory "tsconfig.json") default-directory)))
      (unless root
        (error "Couldn't locate project root folder.  Please make sure to add tsconfig.json in project root folder"))
      (let ((full-path (expand-file-name root)))


### PR DESCRIPTION
When `tsconfig.json` is not found in a dominating directory of the `default-directory`, just use `default-directory` as `tide-project-root`.

This allows you to use language service features within a single standalone file.