### PR TITLE
Remove pkg file

### DIFF
--- a/tide-pkg.el
+++ b/tide-pkg.el
@@ -1,5 +1,0 @@
-(define-package "tide" "0.1" "Typescript Interactive Development Environment"
-  '((typescript-mode "0.1")
-    (emacs "24.1")
-    (flycheck "0.23")
-    (dash "2.10.0")))


### PR DESCRIPTION
Because package information is also declared at package header in tide.el
and pkg file content does not match with package header in tide.el.
This is confused.