### PR TITLE
Make `tide-references` jump directly to a single reference

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -778,12 +778,37 @@ number."
       (goto-char (point-min))
       (current-buffer))))
 
+(defun tide-is-identical-reference (original second)
+  (and (equal (plist-get original :file) (plist-get second :file))
+       (eq (tide-plist-get original :start :line) (tide-plist-get second :start :line))))
+(defun tide-find-single-usage (references)
+  (let ((definition nil)
+        (usage nil)
+        (multiple nil))
+    (-each references
+      #'(lambda (reference)
+          (if (eq t (plist-get reference :isDefinition))
+              (if (or (eq definition nil) (tide-is-identical-reference definition reference))
+                  (setq definition reference)
+                (setq multiple t))
+            (if (or (eq usage nil) (tide-is-identical-reference usage reference))
+                (setq usage reference)
+              (setq multiple t)))))
+    (if (and (not multiple) usage definition)
+        usage
+      nil)))
+
 (defun tide-references ()
   "List all references to the symbol at point."
   (interactive)
   (let ((response (tide-command:references)))
     (if (tide-response-success-p response)
-        (display-buffer (tide-insert-references (tide-plist-get response :body :refs)))
+        (let ((references (tide-plist-get response :body :refs)))
+          (-if-let (usage (tide-find-single-usage references))
+              (progn
+                (message "This is the only usage.")
+                (tide-jump-to-filespan usage nil t))
+            (display-buffer (tide-insert-references references))))
       (message (plist-get response :message)))))
 
 


### PR DESCRIPTION
If there is a single usage of a symbol, then tide-references jumps directly to it instead of creating a \*tide-references\* buffer. Then tide-jump-to-definition jumps back to the definition. For example:

```ts
/*1*/function usedOnce() { }
/*2*/usedOnce();
```

When the cursor is at (1), `tide-references` jumps to (2). When the cursor is at (2), `tide-jump-to-definition` jumps to (1). Otherwise (in case there is more than one usage or more than one declaration), \*tide-references\* is created normally.

Note that this requires TypeScript 2.0, which adds isDefinition to ReferenceEntry to support this feature.

Fixes #55