### PR TITLE
Make references support next-error and previous-error.

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -695,6 +695,16 @@ With a prefix arg, Jump to the type definition."
 
 ;;; References
 
+(defun tide-next-error-function (n &optional reset)
+  "Override for `next-error-function' for use in tide-reference-mode buffers."
+  (interactive "p")
+
+  (with-current-buffer (get-buffer-create "*tide-references*")
+    (if (> n 0)
+        (tide-find-next-reference (point) n)
+      (tide-find-previous-reference (point) (- n)))
+    (tide-goto-reference)))
+
 (defun tide-find-next-reference (pos arg)
   "Move to next reference."
   (interactive "d\np")
@@ -823,7 +833,9 @@ number."
               (progn
                 (message "This is the only usage.")
                 (tide-jump-to-filespan usage nil t))
-            (display-buffer (tide-insert-references references))))
+            (progn
+              (display-buffer (tide-insert-references references))
+              (setq next-error-function #'tide-next-error-function))))
       (message (plist-get response :message)))))
 
 

--- a/tide.el
+++ b/tide.el
@@ -699,11 +699,15 @@ With a prefix arg, Jump to the type definition."
   "Override for `next-error-function' for use in tide-reference-mode buffers."
   (interactive "p")
 
-  (with-current-buffer (get-buffer-create "*tide-references*")
-    (if (> n 0)
-        (tide-find-next-reference (point) n)
-      (tide-find-previous-reference (point) (- n)))
-    (tide-goto-reference)))
+  (let ((buffer (get-buffer "*tide-references*")))
+    (when buffer
+      (with-current-buffer buffer
+        (when reset
+          (beginning-of-buffer))
+        (if (> n 0)
+            (tide-find-next-reference (point) n)
+          (tide-find-previous-reference (point) (- n)))
+        (tide-goto-reference)))))
 
 (defun tide-find-next-reference (pos arg)
   "Move to next reference."
@@ -737,6 +741,7 @@ With a prefix arg, Jump to the type definition."
     (define-key map (kbd "n") #'tide-find-next-reference)
     (define-key map (kbd "p") #'tide-find-previous-reference)
     (define-key map (kbd "C-m") #'tide-goto-reference)
+    (define-key map (kbd "q") #'quit-window)
     map))
 
 (define-derived-mode tide-references-mode nil "tide-references"
@@ -833,9 +838,8 @@ number."
               (progn
                 (message "This is the only usage.")
                 (tide-jump-to-filespan usage nil t))
-            (progn
-              (display-buffer (tide-insert-references references))
-              (setq next-error-function #'tide-next-error-function))))
+            (display-buffer (tide-insert-references references))
+            (setq next-error-function #'tide-next-error-function)))
       (message (plist-get response :message)))))
 
 


### PR DESCRIPTION
After looking into this, I found out that setting text-properties in a `compilation-mode` buffer is troublesome. Basically they will get constantly wiped, as `compilation-mode` tries to update its own properties (and handle the fact that it can be used in a comint).

Working around this would require quite some cumbersome hacks, and possibly have to rely on Emacs' current implementation of `compilation-mode`. Leaving aside the stability and compatibility issues that would entail, it also wouldn't really create any nicer code than what we already have.

And since you insisted on the formatting to stay pretty much exactly as it already is... I decided to try another approach which did not rely on `compilation-mode` directly: I looked into what `next-error` and `previous-error` does and how `compilation-mode` and `occur-mode` hooks into them.

And that was actually very simple. Using your existing references-functions I was able to just add the following snippet, and now it works.

The results are in this PR. This closes https://github.com/ananthakumaran/tide/issues/61