### PR TITLE
Fix screencast in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *TypeScript Interactive Development Environment for Emacs*
 
-![screencast](http://i.imgur.com/jEwgPsd.gif)
+![screencast](http://i.imgur.com/pJiqzQW.gif)
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *TypeScript Interactive Development Environment for Emacs*
 
-[screencast](http://i.imgur.com/jEwgPsd.gif)
+![screencast](http://i.imgur.com/jEwgPsd.gif)
 
 ### Installation
 


### PR DESCRIPTION
Use inline image-reference.

Original GIF replaced with an optimized GIF, because original exceeded Github's maximum content-length.