### PR TITLE
Make doc-view mode read-only and easily closed.

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -270,10 +270,13 @@ LINE is one based, OFFSET is one based and column is zero based"
 
 (defun tide-doc-buffer (string)
   (with-current-buffer (get-buffer-create "*tide-documentation*")
-    (erase-buffer)
-    (when string
-      (save-excursion
-        (insert string)))
+    (setq buffer-read-only t)
+    (let ((inhibit-read-only t))
+      (erase-buffer)
+      (when string
+        (save-excursion
+          (insert string))))
+    (local-set-key (kbd "q") #'quit-window)
     (current-buffer)))
 
 ;;; Server


### PR DESCRIPTION
With current implementation `tide-documentation-at-point` returns a buffer where you can edit it's content and you have to manually kill the buffer when you're done working with it.

This patch makes the documentation-buffer read-only, and makes it easily closable according to existing Emacs-conventions by simply pressing "q".