### PR TITLE
Add the option to see more autocompletion details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@
 (add-hook 'before-save-hook 'tide-format-before-save)
 
 (add-hook 'typescript-mode-hook #'setup-tide-mode)
+
+;; format options
+(setq tide-format-options '(:insertSpaceAfterFunctionKeywordForAnonymousFunctions t :placeOpenBraceOnNewLineForFunctions nil))
 ```
 Check [here][format_options] for the full list of supported format options.
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,6 @@
 (add-hook 'before-save-hook 'tide-format-before-save)
 
 (add-hook 'typescript-mode-hook #'setup-tide-mode)
-
-;; format options
-(setq tide-format-options '(:insertSpaceAfterFunctionKeywordForAnonymousFunctions t :placeOpenBraceOnNewLineForFunctions nil))
 ```
 Check [here][format_options] for the full list of supported format options.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@
 
 ;; format options
 (setq tide-format-options '(:insertSpaceAfterFunctionKeywordForAnonymousFunctions t :placeOpenBraceOnNewLineForFunctions nil))
+
+;; Optional: See more detailed (but cluttered) type information in the autocompletion drop-down
+(setq tide-completion-detailed t)
 ```
 Check [here][format_options] for the full list of supported format options.
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@
 
 ;; format options
 (setq tide-format-options '(:insertSpaceAfterFunctionKeywordForAnonymousFunctions t :placeOpenBraceOnNewLineForFunctions nil))
-
-;; Optional: See more detailed (but cluttered) type information in the autocompletion drop-down
-(setq tide-completion-detailed t)
 ```
 Check [here][format_options] for the full list of supported format options.
 

--- a/tide.el
+++ b/tide.el
@@ -654,10 +654,10 @@ With a prefix arg, Jump to the type definition."
 ;;; Auto completion
 
 (defun tide-completion-annotation (name)
-  (if tide-completion-detailed
+  (if tide-completion-detailed (tide-completion-meta name)
       ;; This is similar to tide-quickinfo-text, but `name` is in a slightly different format.
-      (tide-annotate-display-parts
-       (plist-get (car (plist-get (tide-completion-entry-details name) :body)) :displayParts))
+      ;; (tide-annotate-display-parts
+       ;; (plist-get (car (plist-get (tide-completion-entry-details name) :body)) :displayParts))
     (pcase (plist-get (get-text-property 0 'completion name) :kind)
       ("keyword" " k")
       ("module" " M")
@@ -1469,6 +1469,6 @@ timeout."
   (tide-start-server)
   (tide-each-buffer (tide-project-name) #'tide-configure-buffer))
 
-(provide 'tide)
+(provide 'my-tide)
 
 ;;; tide.el ends here

--- a/tide.el
+++ b/tide.el
@@ -1467,6 +1467,6 @@ timeout."
   (tide-start-server)
   (tide-each-buffer (tide-project-name) #'tide-configure-buffer))
 
-(provide 'my-tide)
+(provide 'tide)
 
 ;;; tide.el ends here

--- a/tide.el
+++ b/tide.el
@@ -654,10 +654,8 @@ With a prefix arg, Jump to the type definition."
 ;;; Auto completion
 
 (defun tide-completion-annotation (name)
-  (if tide-completion-detailed (tide-completion-meta name)
-      ;; This is similar to tide-quickinfo-text, but `name` is in a slightly different format.
-      ;; (tide-annotate-display-parts
-       ;; (plist-get (car (plist-get (tide-completion-entry-details name) :body)) :displayParts))
+  (if tide-completion-detailed
+      (tide-completion-meta name)
     (pcase (plist-get (get-text-property 0 'completion name) :kind)
       ("keyword" " k")
       ("module" " M")

--- a/tide.el
+++ b/tide.el
@@ -81,6 +81,9 @@ above."
 (defvar tide-completion-ignore-case nil
   "CASE will be ignored in completion if set to non-nil.")
 
+(defvar tide-completion-detailed nil
+  "Completion dropdown will contain detailed method information if set to non-nil.")
+
 (defface tide-file
   '((t (:inherit dired-header)))
   "Face for file names in references output."
@@ -650,34 +653,38 @@ With a prefix arg, Jump to the type definition."
 
 ;;; Auto completion
 
-(defun tide-completion-annotation (completion)
-  (pcase (plist-get completion :kind)
-    ("keyword" " k")
-    ("module" " M")
-    ("class" " C")
-    ("interface" " I")
-    ("type" " T")
-    ("enum" " E")
-    ("var" " v")
-    ("local var" " v")
-    ("function" " ƒ")
-    ("local function" " ƒ")
-    ("method" " m")
-    ("getter" " m")
-    ("setter" " m")
-    ("property" " p")
-    ("constructor" " c")
-    ("call" " m")
-    ("index" " i")
-    ("construct" " m")
-    ("parameter" " p")
-    ("type parameter" " T")
-    ("primitive type" " T")
-    ("label" " l")
-    ("alias" " A")
-    ("const" " c")
-    ("let" " l")
-    (t nil)))
+(defun tide-completion-annotation (name)
+  (if tide-completion-detailed
+      ;; This is similar to tide-quickinfo-text, but `name` is in a slightly different format.
+      (tide-annotate-display-parts
+       (plist-get (car (plist-get (tide-completion-entry-details name) :body)) :displayParts))
+    (pcase (plist-get (get-text-property 0 'completion name) :kind)
+      ("keyword" " k")
+      ("module" " M")
+      ("class" " C")
+      ("interface" " I")
+      ("type" " T")
+      ("enum" " E")
+      ("var" " v")
+      ("local var" " v")
+      ("function" " ƒ")
+      ("local function" " ƒ")
+      ("method" " m")
+      ("getter" " m")
+      ("setter" " m")
+      ("property" " p")
+      ("constructor" " c")
+      ("call" " m")
+      ("index" " i")
+      ("construct" " m")
+      ("parameter" " p")
+      ("type parameter" " T")
+      ("primitive type" " T")
+      ("label" " l")
+      ("alias" " A")
+      ("const" " c")
+      ("let" " l")
+      (t nil))))
 
 (defun tide-completion-prefix ()
   (company-grab-symbol-cons "\\." 1))
@@ -764,7 +771,7 @@ With a prefix arg, Jump to the type definition."
     (sorted t)
     (ignore-case tide-completion-ignore-case)
     (meta (tide-completion-meta arg))
-    (annotation (tide-completion-annotation (get-text-property 0 'completion arg)))
+    (annotation (tide-completion-annotation arg))
     (doc-buffer (tide-completion-doc-buffer arg))))
 
 (eval-after-load 'company


### PR DESCRIPTION
#82 Previously, only an abbreviation for the type of the candidate was
shown. Now, the user has the option of seeing the full type signature,
like the following image:
https://cloud.githubusercontent.com/assets/149238/20646233/8c14f36e-b49c-11e6-8899-6a50009f34de.png