### PR TITLE
Rename: prettify symbol-name presented when doing rename-refactoring

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -981,7 +981,7 @@ number."
     (tide-on-response-success response
       (if (eq (tide-plist-get response :body :info :canRename) :json-false)
           (message "%s" (tide-plist-get response :body :info :localizedErrorMessage))
-        (let* ((old-symbol (tide-plist-get response :body :info :fullDisplayName))
+        (let* ((old-symbol (tide-plist-get response :body :info :displayName))
                (new-symbol (tide-read-new-symbol old-symbol))
                (locs (tide-plist-get response :body :locs))
                (count 0))


### PR DESCRIPTION
Currently the current code *may* produce something like the following
in the minibuffer:

````
Rename "d:/repo/src/ui/viewBase".ViewBase to: "d:/repo/src/ui/viewBase".ViewBase
````

With this commit, we get the symbol-name only, as expected:

````
Rename ViewBase to: ViewBase
````