### PR TITLE
Ensure annotations are only one line.

### DIFF
--- a/example/test.ts
+++ b/example/test.ts
@@ -6,6 +6,8 @@ len.substring(0, 1);
 
 var y = Game;
 
+var obj: Object;
+
 @readonly
 class Person {
     name: string;

--- a/tide.el
+++ b/tide.el
@@ -661,7 +661,9 @@ With a prefix arg, Jump to the type definition."
 
 (defun tide-completion-annotation (name)
   (if tide-completion-detailed
-      (tide-completion-meta name)
+      ;; Get everything before the first newline, if any, because company-mode
+      ;; wants single-line annotations.
+      (car (split-string (tide-completion-meta name) "\n"))
     (pcase (plist-get (get-text-property 0 'completion name) :kind)
       ("keyword" " k")
       ("module" " M")


### PR DESCRIPTION
Otherwise, company-mode will throw an error when
company-tooltip-align-annotations is non-nil. Also
added a line in example/test.ts that repro-ed this,
because the Object type had a multi-line annotation.