### PR TITLE
Fix tide-nav for helm.

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -541,7 +541,10 @@ Noise can be anything like braces, reserved keywords, etc."
 
   (when (not (member (face-at-point) '(font-lock-keyword-face
                                        font-lock-comment-delimiter-face)))
-    (let* ((symbol (region-str-or-symbol))
+    ;; we could have used symbol-at-point here, but that leaves us unable to
+    ;; differentiate between a symbol named nil and no symbol at all.
+    ;; thing-at-point returns a string OR nil, which means we don't get this problem.
+    (let* ((symbol (thing-at-point 'symbol))
            (value (substring-no-properties (if (equal nil symbol) "" symbol))))
       (save-match-data
         (when (not (string-match "{|}|;|[|]" value))

--- a/tide.el
+++ b/tide.el
@@ -539,12 +539,9 @@ With a prefix arg, Jump to the type definition."
   "Search and navigate to named types."
   (interactive)
   (let ((completion-ignore-case t)
-        (last-completions nil)
-        ;; helm does not work well with dynamically/incrementally
-        ;; generated tables, so disable it for this function!
-        (helm-completing-read-handlers-alist '()))
+        (last-completions nil))
     (-when-let (completion
-                (completing-read
+                (completing-read-default
                  "Search: "
                  (completion-table-dynamic
                   (lambda (prefix)


### PR DESCRIPTION
After doing (better) testing of `tide-nav`, I discovered the following:

* my hacky "disable helm" workaround doesn't actually seem to work reliably. I must have messed something up during testing.
* Getting "something" which works in helm wasn't that hard.

This patch lets you type something, then press `<TAB>`(just as a regular completing-read would have you do) and then you get a helm-popup with the candidates, ready for selection. Much better than it used to be.

To avoid more errors in this department I've tested the following configurations:

* helm
* ido
* ivy
* none of the above

From what I can tell it all works as expected now.