### PR TITLE
Fix newline issues with code-edits.

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -1115,11 +1115,28 @@ number."
       (tide-format-region (region-beginning) (region-end))
     (tide-format-region (point-min) (point-max))))
 
+(defun tide-normalize-lineshift (str)
+  "Reformat `STR' to only contain line-shift formats expected by Emacs.
+
+When inserting text in an Emacs-buffer Emacs only ever expects \n
+for newlines, no matter what the actual encoding of the file
+is.  Inserting anything else causes issues with formatting and
+code-analysis, so clean it up!"
+
+  (save-match-data
+    ;; convert DOS CR+LF to LF
+    (while (string-match "\r\n" str)
+      (setq str (replace-match "\n" nil nil str)))
+    ;; conveer Mac CR to LF
+    (while (string-match "\r" str)
+      (setq str (replace-match "\n" nil nil str))))
+  str)
+
 (defun tide-apply-edit (edit)
   (goto-char (tide-location-to-point (plist-get edit :start)))
   (delete-region (point) (tide-location-to-point (plist-get edit :end)))
   (let ((start (point-marker)))
-    (insert (plist-get edit :newText))
+    (insert (tide-normalize-lineshift (plist-get edit :newText)))
     (cons start (point-marker))))
 
 (defun tide-apply-edits (edits)

--- a/tide.el
+++ b/tide.el
@@ -1123,13 +1123,10 @@ for newlines, no matter what the actual encoding of the file
 is.  Inserting anything else causes issues with formatting and
 code-analysis, so clean it up!"
 
-  (save-match-data
-    ;; convert DOS CR+LF to LF
-    (while (string-match "\r\n" str)
-      (setq str (replace-match "\n" nil nil str)))
-    ;; conveer Mac CR to LF
-    (while (string-match "\r" str)
-      (setq str (replace-match "\n" nil nil str))))
+  ;; convert DOS CR+LF to LF
+  (setq str (replace-regexp-in-string "\r\n" "\n" str))
+  ;; convert Mac CR to LF
+  (setq str (subst-char-in-string ?\r ?\n str))
   str)
 
 (defun tide-apply-edit (edit)


### PR DESCRIPTION
As discussed in issue #122, Emacs actually never expects anything except `\n` to be inserted in a buffer for newlines, no matter how newlines is actually represented in that file.

Us inserting `^M` characters returned from `tsserver` is thus not us doing things properly nor preserving correctness. On the contrary it's our code being a source of (quite terrible!) bugs.

This PR fixes this and closes #122.