### PR TITLE
Don't convert location to point unnecessarily.

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -529,10 +529,9 @@ implementations.  When invoked with a prefix arg, jump to the type definition."
 
 (defun tide-filespan-is-current-location-p (filespan)
   (let* ((location (plist-get filespan :start))
-         (new-file-name (plist-get filespan :file))
-         (new-point (tide-location-to-point location)))
-    (and (equal new-point (point))
-         (string-equal new-file-name buffer-file-name))))
+         (new-file-name (plist-get filespan :file)))
+    (and (string-equal new-file-name buffer-file-name)
+         (equal (tide-location-to-point location) (point)))))
 
 (defun tide-move-to-location (location)
   (let* ((line (plist-get location :line))


### PR DESCRIPTION
The previous version of this function would always convert the location to point before doing the comparison. When the location was to a point that is greater than the size of the current buffer, it would cause a fatal error. The new version will do the conversion of location to point only if the current buffer's file name and the other file name are a match.

