### PR TITLE
Bug Fix: use expand file name to get full tsfmt.json path

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -464,7 +464,7 @@ LINE is one based, OFFSET is one based and column is zero based"
    (tide-tsfmt-options)))
 
 (defun tide-tsfmt-options ()
-  (let ((config-file (file-relative-name "tsfmt.json" (tide-project-root))))
+  (let ((config-file (expand-file-name "tsfmt.json" (tide-project-root))))
     (when (file-exists-p config-file)
       (tide-safe-json-read-file config-file))))
 


### PR DESCRIPTION
`file-relative-name` returns relative path for `tsmft.json` in the current directory, often producing something like `src/component/tsfmt.json`
`expand-file-name` provides the intended behaviour.
