### PR TITLE
Don't error out on an empty definition response

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -517,7 +517,7 @@ implementations.  When invoked with a prefix arg, jump to the type definition."
   (interactive "P")
   (let ((cb (lambda (response)
               (tide-on-response-success response
-                (let ((filespan (car (plist-get response :body))))
+                (-when-let (filespan (car (plist-get response :body)))
                   ;; if we're still at the same location...
                   ;; maybe we're a abstract member which has impementations?
                   (if (and (not arg)


### PR DESCRIPTION
Apparently, `definition` tsserver requests can sometimes return a success code but with a body that is an empty array. I was seeing this in my tsserver log when using `tide-jump-to-definition` in some code:

```
Info 62   request: {"command":"definition","seq":"5886","arguments":{"file":"<filename redacted>","line":42,"offset":45}}
Perf 63   5886::definition: elapsed time (in milliseconds) 3.9150
Info 64   response: {"seq":0,"type":"response","command":"definition","request_seq":"5886","success":true,"body":[]}
```

Which was causing tide to throw these error messages:

```
error in process filter: Wrong type argument: stringp, nil
```

This PR effectively just silences that error--I don't know if there's anything better to do in that situation, though I might look and see why tsserver can't find the definition (because it really should have been able to, for the code I'm experiencing this on)

In case it's useful for anything, the full backtrace looked like:
```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  expand-file-name(nil)
  find-file-noselect(nil)
  (pop-to-buffer (find-file-noselect file) (quote ((display-buffer-reuse-window display-buffer-same-window))))
  (if reuse-window (pop-to-buffer (find-file-noselect file) (quote ((display-buffer-reuse-window display-buffer-same-window)))) (pop-to-buffer (find-file-noselect file)))
  (let ((file (plist-get filespan :file))) (if no-marker nil (ring-insert find-tag-marker-ring (point-marker))) (if reuse-window (pop-to-buffer (find-file-noselect file) (quote ((display-buffer-reuse-window display-buffer-same-window)))) (pop-to-buffer (find-file-noselect file))) (tide-move-to-location (plist-get filespan :start)))
  tide-jump-to-filespan(nil t)
  (if (and (not arg) (tide-filespan-is-current-location-p filespan)) (tide-jump-to-implementation) (tide-jump-to-filespan filespan tide-jump-to-definition-reuse-window))
  (let ((filespan (car (plist-get response :body)))) (if (and (not arg) (tide-filespan-is-current-location-p filespan)) (tide-jump-to-implementation) (tide-jump-to-filespan filespan tide-jump-to-definition-reuse-window)))
  (if (tide-response-success-p response) (let ((filespan (car (plist-get response :body)))) (if (and (not arg) (tide-filespan-is-current-location-p filespan)) (tide-jump-to-implementation) (tide-jump-to-filespan filespan tide-jump-to-definition-reuse-window))) (let ((msg (plist-get response :message))) (if msg (progn (message "%s" msg)))) nil)
  (closure ((arg) web-mode-code-indent-offset js3-indent-level t) (response) (if (tide-response-success-p response) (let ((filespan (car (plist-get response :body)))) (if (and (not arg) (tide-filespan-is-current-location-p filespan)) (tide-jump-to-implementation) (tide-jump-to-filespan filespan tide-jump-to-definition-reuse-window))) (let ((msg (plist-get response :message))) (if msg (progn (message "%s" msg)))) nil))((:seq 0 :type "response" :command "definition" :request_seq "5912" :success t :body nil))
  apply((closure ((arg) web-mode-code-indent-offset js3-indent-level t) (response) (if (tide-response-success-p response) (let ((filespan (car (plist-get response :body)))) (if (and (not arg) (tide-filespan-is-current-location-p filespan)) (tide-jump-to-implementation) (tide-jump-to-filespan filespan tide-jump-to-definition-reuse-window))) (let ((msg (plist-get response :message))) (if msg (progn (message "%s" msg)))) nil)) (:seq 0 :type "response" :command "definition" :request_seq "5912" :success t :body nil))
  (save-current-buffer (set-buffer (car callback)) (apply (cdr callback) (list response)))
  (progn (save-current-buffer (set-buffer (car callback)) (apply (cdr callback) (list response))) (remhash request-id tide-response-callbacks))
  (if callback (progn (save-current-buffer (set-buffer (car callback)) (apply (cdr callback) (list response))) (remhash request-id tide-response-callbacks)))
  (let* ((request-id (plist-get response :request_seq)) (callback (gethash request-id tide-response-callbacks))) (if callback (progn (save-current-buffer (set-buffer (car callback)) (apply (cdr callback) (list response))) (remhash request-id tide-response-callbacks))))
  tide-dispatch-response((:seq 0 :type "response" :command "definition" :request_seq "5912" :success t :body nil))
  (cond ((memql temp (quote (quote response))) (tide-dispatch-response response)) ((memql temp (quote (quote event))) (tide-dispatch-event response)))
  (let* ((temp (intern (plist-get response :type)))) (cond ((memql temp (quote (quote response))) (tide-dispatch-response response)) ((memql temp (quote (quote event))) (tide-dispatch-event response))))
  tide-dispatch((:seq 0 :type "response" :command "definition" :request_seq "5912" :success t :body nil))
  (progn (tide-dispatch (prog2 (progn (search-forward "{") (backward-char 1)) (json-read-object) (delete-region (point-min) (point)))) (if (>= (buffer-size) 16) (progn (tide-decode-response process))))
  (if (and length (tide-enough-response-p length)) (progn (tide-dispatch (prog2 (progn (search-forward "{") (backward-char 1)) (json-read-object) (delete-region (point-min) (point)))) (if (>= (buffer-size) 16) (progn (tide-decode-response process)))))
  (let ((length (tide-decode-response-legth)) (json-object-type (quote plist)) (json-array-type (quote list))) (if (and length (tide-enough-response-p length)) (progn (tide-dispatch (prog2 (progn (search-forward "{") (backward-char 1)) (json-read-object) (delete-region (point-min) (point)))) (if (>= (buffer-size) 16) (progn (tide-decode-response process))))))
  (save-current-buffer (set-buffer (process-buffer process)) (let ((length (tide-decode-response-legth)) (json-object-type (quote plist)) (json-array-type (quote list))) (if (and length (tide-enough-response-p length)) (progn (tide-dispatch (prog2 (progn (search-forward "{") (backward-char 1)) (json-read-object) (delete-region (point-min) (point)))) (if (>= (buffer-size) 16) (progn (tide-decode-response process)))))))
  tide-decode-response(#<process tsserver>)
  tide-net-filter(#<process tsserver> "Content-Length: 97
\n
\n{\"seq\":0,\"type\":\"response\",\"command\":\"definition\",\"request_seq\":\"5912\",\"success\":true,\"body\":[]}\n")
```
