### PR TITLE
Filter & sort completion candidates by kind

### DIFF
--- a/tide-tests.el
+++ b/tide-tests.el
@@ -22,6 +22,7 @@
     (package-install p)))
 
 (require 'tide)
+(require 'dash)
 
 ;; actual tests:
 
@@ -30,6 +31,54 @@
 
   (should (equal "this\nis\nfour\nlines"
                  (tide-normalize-lineshift "this\nis\r\nfour\nlines"))))
+
+(ert-deftest member-completetions-get-filtered ()
+  "Tests that completions get filtered by kind."
+  (let ((mock-completions
+         '(
+           (:name "DOMError" :kind "interface" :kindModifiers "declare")
+           (:name "data" :kind "property" :kindModifiers)
+           (:name "declare" :kind "keyword" :kindModifiers)
+           (:name "decode" :kind "method" :kindModifiers "declare")
+           (:name "deleteText" :kind "local function" :kindModifiers)))
+        (filtered-completions
+         '((:name "data" :kind "property" :kindModifiers)
+           (:name "decode" :kind "method" :kindModifiers "declare"))))
+    (should (-same-items?
+             (-filter
+              (lambda (completion)
+                (tide-kind-member-p (plist-get completion :kind)))
+              mock-completions)
+             filtered-completions))))
+
+(ert-deftest completions-get-sorted ()
+  "Tests that completion candidates get sorted by kind."
+  (let ((mock-completions
+         '(
+           (:name "DOMError" :kind "interface" :kindModifiers "declare")
+           (:name "data" :kind "var" :kindModifiers)
+           (:name "debugger" :kind "keyword" :kindModifiers)
+           (:name "declare" :kind "keyword" :kindModifiers)
+           (:name "decodeURI" :kind "function" :kindModifiers "declare")
+           (:name "decodeURIComponent" :kind "function" :kindModifiers "declare")
+           (:name "deleteText" :kind "local function" :kindModifiers)
+           (:name "dimensions" :kind "parameter" :kindModifiers)
+           (:name "document" :kind "var" :kindModifiers "declare")))
+        (sorted-completions
+         '(
+           (:name "dimensions" :kind "parameter" :kindModifiers)
+           (:name "data" :kind "var" :kindModifiers)
+           (:name "deleteText" :kind "local function" :kindModifiers)
+           (:name "debugger" :kind "keyword" :kindModifiers)
+           (:name "declare" :kind "keyword" :kindModifiers)
+           (:name "document" :kind "var" :kindModifiers "declare")
+           (:name "decodeURI" :kind "function" :kindModifiers "declare")
+           (:name "decodeURIComponent" :kind "function" :kindModifiers "declare")
+           (:name "DOMError" :kind "interface" :kindModifiers "declare"))
+         ))
+    (should (-same-items?
+             (-sort 'tide-compare-completions mock-completions)
+             sorted-completions))))
 
 (provide 'tide-tests)
 


### PR DESCRIPTION
This PR solves two issues with the code completion.

### 1. Member completion

When completing properties and methods of an object, Tide would list all possible symbols as candidates.

_Edit_: I've just realized this behavior can be reproduced only for JavaScript files, not if I put the same code into a `.ts` file. 🤷‍♂️ 

Before the patch:

<img width="481" alt="screen shot 2017-05-06 at 17 32 34" src="https://cloud.githubusercontent.com/assets/381895/25773694/403ccd86-3282-11e7-82af-ad406548a810.png">

With the patch – we display only the properties and methods of the object at point:

<img width="469" alt="screen shot 2017-05-06 at 17 35 12" src="https://cloud.githubusercontent.com/assets/381895/25773700/637b2a18-3282-11e7-8bac-a0dc9c73d836.png">

### 2. Candidate sorting
When completing a variable, Tide provides all possible symbols in the scope, sorted alphabetically.

It would be nicer to sort the candidates by scope. First, show the function parameters and locally defined variables, then local functions and outer variables, and finally library functions (i.e. declarations from typings).

Before:

<img width="526" alt="screen shot 2017-05-06 at 17 32 21" src="https://cloud.githubusercontent.com/assets/381895/25773725/d6dec2c6-3282-11e7-89fd-ee60a0a7faa0.png">

After:

<img width="523" alt="screen shot 2017-05-06 at 17 39 28" src="https://cloud.githubusercontent.com/assets/381895/25773728/f99d2604-3282-11e7-9a04-116173afc4db.png">

---

What do you think? I would be glad to incorporate any feedback or discuss a better solution. Thanks!