### PR TITLE
fix: removed filtering of member completions (see #149)

### DIFF
--- a/tide-tests.el
+++ b/tide-tests.el
@@ -32,25 +32,6 @@
   (should (equal "this\nis\nfour\nlines"
                  (tide-normalize-lineshift "this\nis\r\nfour\nlines"))))
 
-(ert-deftest member-completetions-get-filtered ()
-  "Tests that completions get filtered by kind."
-  (let ((mock-completions
-         '(
-           (:name "DOMError" :kind "interface" :kindModifiers "declare")
-           (:name "data" :kind "property" :kindModifiers)
-           (:name "declare" :kind "keyword" :kindModifiers)
-           (:name "decode" :kind "method" :kindModifiers "declare")
-           (:name "deleteText" :kind "local function" :kindModifiers)))
-        (filtered-completions
-         '((:name "data" :kind "property" :kindModifiers)
-           (:name "decode" :kind "method" :kindModifiers "declare"))))
-    (should (-same-items?
-             (-filter
-              (lambda (completion)
-                (tide-kind-member-p (plist-get completion :kind)))
-              mock-completions)
-             filtered-completions))))
-
 (ert-deftest completions-get-sorted ()
   "Tests that completion candidates get sorted by kind."
   (let ((mock-completions

--- a/tide.el
+++ b/tide.el
@@ -897,10 +897,6 @@ Noise can be anything like braces, reserved keywords, etc."
     (and (> (point) (point-min))
          (equal (string (char-before (point))) "."))))
 
-(defun tide-kind-member-p (kind)
-  "Check if a completion's KIND is a property or method."
-  (member kind '("method" "property" "getter" "setter")))
-
 (defun tide-annotate-completions (completions prefix file-location)
   (-map
    (lambda (completion)
@@ -911,10 +907,8 @@ Noise can be anything like braces, reserved keywords, etc."
    (-sort
     'tide-compare-completions
     (-filter
-     (let ((member-p (tide-member-completion-p prefix)))
-       (lambda (completion)
-         (and (string-prefix-p prefix (plist-get completion :name))
-              (or (not member-p) (tide-kind-member-p (plist-get completion :kind))))))
+     (lambda (completion)
+       (string-prefix-p prefix (plist-get completion :name)))
      completions))))
 
 (defun tide-command:completions (prefix cb)


### PR DESCRIPTION
This PR resolves #149 by removing the additional client-side filtering of code completion candidates.

