### PR TITLE
Define a search criteria for the tsserver executable.

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -464,7 +464,7 @@ Return a string representing the path or nil."
 (defun tide--project-package-bin ()
   "Return the package's node_module bin directory using projectile's project root or nil."
   (when (and (functionp 'projectile-project-p) (projectile-project-p))
-    (concat (projectile-project-p) "node_modules/typescript/lib")))
+    (concat (projectile-project-root) "node_modules/typescript/lib")))
 
 (defun tide--tsserver-file-name ()
   "Return a string representing the full path to the typescript server, including the system's extension, or nil."

--- a/tide.el
+++ b/tide.el
@@ -460,6 +460,11 @@ Return a string representing the path or nil."
                              "bin" global-switch))
         (string-trim-right (buffer-string))))))
 
+(defun tide--project-package-bin ()
+  "Return the package's node_module bin directory using projectile's project root or nil."
+  (when (functionp 'projectile-project-root)
+    (concat (projectile-project-root) "node_modules/.bin/")))
+
 (defun tide--tsserver-file-name ()
   "Return a string representing the full path to the typescript server, including the system's extension, or nil."
   (let ((extension (if (eq system-type 'windows-nt) ".cmd" "")))
@@ -472,10 +477,11 @@ Return a string representing the path or nil."
 
 (defun tide-locate-tsserver-executable ()
   "Locate the typescript server executable.
-If TIDE-TSSERVER-EXECUTABLE is set by the user use it.  Otherwise check npm package local first and npm global installation after.  If nothing is found use the bundled version."
+If TIDE-TSSERVER-EXECUTABLE is set by the user use it.  Otherwise check in the npm local package directory, in the project root as defined by projectile, and in the npm global installation.  If nothing is found use the bundled version."
   (or
    (and tide-tsserver-executable (expand-file-name tide-tsserver-executable))
    (tide--locate (tide--tsserver-file-name) (tide--npm-bin))
+   (tide--locate (tide--tsserver-file-name) (tide--project-package-bin))
    (tide--locate (tide--tsserver-file-name) (tide--npm-bin 'global))
    (expand-file-name "tsserver.js" tide-tsserver-directory)))
 

--- a/tide.el
+++ b/tide.el
@@ -463,8 +463,8 @@ Return a string representing the path or nil."
 
 (defun tide--project-package-bin ()
   "Return the package's node_module bin directory using projectile's project root or nil."
-  (when (functionp 'projectile-project-root)
-    (concat (projectile-project-root) "node_modules/typescript/lib")))
+  (when (and (functionp 'projectile-project-p) (projectile-project-p))
+    (concat (projectile-project-p) "node_modules/typescript/lib")))
 
 (defun tide--tsserver-file-name ()
   "Return a string representing the full path to the typescript server, including the system's extension, or nil."

--- a/tide.el
+++ b/tide.el
@@ -466,11 +466,6 @@ Return a string representing the path or nil."
   (when (and (functionp 'projectile-project-p) (projectile-project-p))
     (concat (projectile-project-root) "node_modules/typescript/lib")))
 
-(defun tide--tsserver-file-name ()
-  "Return a string representing the full path to the typescript server, including the system's extension, or nil."
-  (let ((extension (if (eq system-type 'windows-nt) ".cmd" "")))
-    (concat "tsserver" extension)))
-
 (defun tide--locate (file-name path)
   "Locate the FILE-NAME in PATH.  Return a string representing the full path or nil."
   (let ((exe (expand-file-name file-name path)))


### PR DESCRIPTION
This is a follow up to #190. It specifies a search order and calls `npm bin` to find `tsserver`.

The search order is:
1. User defined through `tide-tsserver-executable`.
2. Local npm package.
3. Global npm.
4. Bundled version.

⚠️ The code is not tested.

- [X] implement search for `(projectile-project-root)`
- [ ] tests