### PR TITLE
ensure `buffer-file-name` is a string

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -1458,15 +1458,21 @@ code-analysis."
 (defun tide-setup ()
   "Setup `tide-mode' in current buffer."
   (interactive)
-  (tide-start-server-if-required)
-  (tide-mode 1)
-  (set (make-local-variable 'eldoc-documentation-function)
-       'tide-eldoc-function)
-  (set (make-local-variable 'imenu-auto-rescan) t)
-  (set (make-local-variable 'imenu-create-index-function)
-       'tide-imenu-index)
 
-  (tide-configure-buffer))
+  ;; skip buffers where buffer-file-name is not defined, such as org-mode code
+  ;; blocks as they are fontified for html export
+  (if (stringp buffer-file-name)
+      (progn
+        (tide-start-server-if-required)
+        (tide-mode 1)
+        (set (make-local-variable 'eldoc-documentation-function)
+             'tide-eldoc-function)
+        (set (make-local-variable 'imenu-auto-rescan) t)
+        (set (make-local-variable 'imenu-create-index-function)
+             'tide-imenu-index)
+
+        (tide-configure-buffer))
+    (display-warning 'tide "A file backed buffer is required to start the tsserver.")))
 
 ;;;###autoload
 (define-minor-mode tide-mode


### PR DESCRIPTION
`tide-command:openfile` assumes `buffer-file-name` is a string when evaluating its body.
This is not the case when exporting javascript org-mode code blocks to html, for example.
Checking that `buffer-file-name` is a string prevents evaluation errors and returning `nil` is enough for the org-mode export case to work.

This was the top of the stack trace before the change:
```elisp
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  file-name-nondirectory(nil)
  file-name-extension(nil)
  tide-command:openfile()
  tide-configure-buffer()
  tide-setup()
  setup-tide-mode()
  js2-mode()
  funcall(js2-mode)
  org-html-fontify-code("" "js")
```