### PR TITLE
Add support for indirect buffers

### DIFF
--- a/example/all.d.ts
+++ b/example/all.d.ts
@@ -1,1 +1,6 @@
 /// <reference path='./typings/react/react.d.ts' />
+
+declare module "*.vue" {
+  // This should normally reexport the entire 'vue' module
+  export default {};
+}

--- a/example/literate.org
+++ b/example/literate.org
@@ -1,0 +1,50 @@
+Nullam eu ante vel est convallis dignissim. Fusce suscipit, wisi nec facilisis
+facilisis, est dui fermentum leo, quis tempor ligula erat quis odio. Nunc porta
+vulputate tellus. Nunc rutrum turpis sed pede. Sed bibendum. Aliquam posuere.
+Nunc aliquet, augue nec adipiscing interdum, lacus tellus malesuada massa, quis
+varius mi purus non odio. Pellentesque condimentum, magna ut suscipit hendrerit,
+ipsum augue ornare nulla, non luctus diam neque sit amet urna. Curabitur
+vulputate vestibulum lorem. Fusce sagittis, libero non molestie mollis, magna
+orci ultrices dolor, at vulputate neque nulla lacinia eros. Sed id ligula quis
+est convallis tempor. Curabitur lacinia pulvinar nibh. Nam a sapien.
+
+#+BEGIN_SRC typescript
+  class Animal {
+      constructor(public name) { }
+      move(meters) {
+          console.log(this.name + " moved " + meters + "m.");
+      }
+  }
+
+  class Snake extends Animal {
+      move() {
+          console.log("Slithering...");
+          super.move(5);
+      }
+  }
+
+  class Horse extends Animal {
+      move() {
+          console.log("Galloping...");
+          super.move(45);
+      }
+  }
+
+  var sam = new Snake("Sammy the Python");
+  var tom: Animal = new Horse("Tommy the Palomino");
+
+  sam.move();
+  tom.move(34);
+#+END_SRC
+
+Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec hendrerit tempor
+tellus. Donec pretium posuere tellus. Proin quam nisl, tincidunt et, mattis
+eget, convallis nec, purus. Cum sociis natoque penatibus et magnis dis
+parturient montes, nascetur ridiculus mus. Nulla posuere. Donec vitae dolor.
+Nullam tristique diam non turpis. Cras placerat accumsan nulla. Nullam rutrum.
+Nam vestibulum accumsan nisl.
+
+#+BEGIN_SRC typescript
+  // This should show an error as the two snippets are evaluated seperately
+  var tom: Animal = new Horse("Tommy the Palomino");
+#+END_SRC

--- a/example/test.ts
+++ b/example/test.ts
@@ -9,7 +9,7 @@ var y = Game;
 var obj: Object;
 
 @readonly
-class Person {
+export class Person {
     name: string;
     isAdmin: boolean;
 

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -13,6 +13,7 @@
     "all.d.ts",
     "reactComponent.tsx",
     "test.ts",
-    "another.js"
+    "another.js",
+    "vueComponent.vue"
   ]
 }

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -14,6 +14,7 @@
     "reactComponent.tsx",
     "test.ts",
     "another.js",
-    "vueComponent.vue"
+    "vueComponent.vue",
+    "literate.org"
   ]
 }

--- a/example/vueComponent.vue
+++ b/example/vueComponent.vue
@@ -1,0 +1,31 @@
+<template>
+  <p>{{ greeting }} World, visitor {{ visitorId }}!</p>
+</template>
+
+<script lang="ts">
+import {Person} from './test';
+
+const randomNumber: number = Math.random();
+const notANumber: number = 'this should show an error';
+
+const person = new Person('name', 'should have been a boolean');
+
+export default {
+  data: {
+    visitorId: randomNumber
+  },
+  props: {
+    todo: {
+      type: Object,
+      required: true
+    }
+  }
+}
+</script>
+
+<style scoped>
+p {
+  font-size: 2em;
+  text-align: center;
+}
+</style>

--- a/tide.el
+++ b/tide.el
@@ -212,15 +212,14 @@ above."
     (concat (file-name-nondirectory full-path) "-" (substring (md5 full-path) 0 10))))
 
 (defun tide-buffer-file-name ()
-  "Returns either the path to the currently open file. This is
-  needed to support indirect buffers, as they don't set
-  `buffer-file-name' correctly."
-  (or (and (bound-and-true-p edit-indirect--overlay)
-           (buffer-file-name (overlay-buffer edit-indirect--overlay)))
-      (and (bound-and-true-p org-src--overlay)
-           (buffer-file-name (overlay-buffer org-src--overlay)))
-      buffer-file-name
-      (buffer-file-name (buffer-base-buffer))))
+  "Returns the path to either the currently open file or the
+  current buffer's parent. This is needed to support indirect
+  buffers, as they don't set `buffer-file-name' correctly."
+  (buffer-file-name (or (and (bound-and-true-p edit-indirect--overlay)
+                             (overlay-buffer edit-indirect--overlay))
+                        (and (bound-and-true-p org-src--overlay)
+                             (overlay-buffer org-src--overlay))
+                        (buffer-base-buffer))))
 
 ;;; Compatibility
 
@@ -1626,7 +1625,7 @@ code-analysis."
   ;; tsconfig.json, otherwise the file will be loaded as part of an 'inferred
   ;; project'. This won't be necessary anymore after TypeScript allows defining
   ;; custom file extensions. https://github.com/Microsoft/TypeScript/issues/8328
-  (when tide-require-manual-sync
+  (when (and tide-require-manual-sync (tide-buffer-file-name))
     (tide-command:projectInfo
      (lambda (response)
        (tide-on-response-success response nil

--- a/tide.el
+++ b/tide.el
@@ -225,6 +225,9 @@ above."
                              (overlay-buffer edit-indirect--overlay))
                         (and (bound-and-true-p org-src--overlay)
                              (overlay-buffer org-src--overlay))
+                        ;; Needed for org-mode 8.x compatibility
+                        (and (bound-and-true-p org-edit-src-overlay)
+                             (overlay-buffer org-edit-src-overlay))
                         (buffer-base-buffer))))
 
 ;;; Compatibility

--- a/tide.el
+++ b/tide.el
@@ -192,7 +192,7 @@ above."
 (tide-def-permanent-buffer-local tide-buffer-dirty nil)
 (tide-def-permanent-buffer-local tide-buffer-tmp-file nil)
 (tide-def-permanent-buffer-local tide-active-buffer-file-name nil)
-(tide-def-permanent-buffer-local tide-require-manual-sync nil)
+(tide-def-permanent-buffer-local tide-require-manual-setup nil)
 
 (defvar tide-servers (make-hash-table :test 'equal))
 (defvar tide-response-callbacks (make-hash-table :test 'equal))
@@ -661,7 +661,7 @@ If TIDE-TSSERVER-EXECUTABLE is set by the user use it.  Otherwise check in the n
 
 (defun tide-command:openfile ()
   (tide-send-command "open"
-                     (if tide-require-manual-sync
+                     (if tide-require-manual-setup
                          `(:file
                            ,(tide-buffer-file-name)
                            :scriptKindName ,tide-default-mode
@@ -1614,7 +1614,7 @@ code-analysis."
   ;; case we should either add an ignore list or don't do anything at all when
   ;; there are more than a certain amount of snippets.
   (unless (stringp buffer-file-name)
-    (setq tide-require-manual-sync t))
+    (setq tide-require-manual-setup t))
 
   (tide-start-server-if-required)
   (tide-mode 1)
@@ -1630,7 +1630,7 @@ code-analysis."
   ;; tsconfig.json, otherwise the file will be loaded as part of an 'inferred
   ;; project'. This won't be necessary anymore after TypeScript allows defining
   ;; custom file extensions. https://github.com/Microsoft/TypeScript/issues/8328
-  (when (and tide-require-manual-sync (tide-buffer-file-name))
+  (when (and tide-require-manual-setup (tide-buffer-file-name))
     (tide-command:projectInfo
      (lambda (response)
        (tide-on-response-success response nil

--- a/tide.el
+++ b/tide.el
@@ -168,6 +168,12 @@ above."
   :type 'function
   :group 'tide)
 
+(defcustom tide-default-mode "TS"
+  "The default mode to open buffers not backed by files (e.g. Org
+  source blocks) in."
+  :type '(choice (const "TS") (const "TSX") (const "JS")(const  "JSX"))
+  :group 'tide)
+
 (defmacro tide-def-permanent-buffer-local (name &optional init-value)
   "Declare NAME as buffer local variable."
   `(progn
@@ -658,8 +664,7 @@ If TIDE-TSSERVER-EXECUTABLE is set by the user use it.  Otherwise check in the n
                      (if tide-require-manual-sync
                          `(:file
                            ,(tide-buffer-file-name)
-                           ;; TODO: Set this according to a variable or an alist
-                           :scriptKindName "TS"
+                           :scriptKindName ,tide-default-mode
                            :fileContent ,(buffer-string))
                        (append `(:file ,(tide-buffer-file-name))
                                (let ((extension (upcase (file-name-extension (tide-buffer-file-name)))))

--- a/tide.el
+++ b/tide.el
@@ -191,7 +191,7 @@ above."
 (defvar tide-servers (make-hash-table :test 'equal))
 (defvar tide-response-callbacks (make-hash-table :test 'equal))
 
-(defvar tide-source-root-directory (file-name-directory (or load-file-name (tide-buffer-file-name))))
+(defvar tide-source-root-directory (file-name-directory (or load-file-name buffer-file-name)))
 (defvar tide-tsserver-directory (expand-file-name "tsserver" tide-source-root-directory))
 
 (defun tide-project-root ()
@@ -277,6 +277,14 @@ ones and overrule settings in the other lists."
         (setq p (pop ls) v (pop ls))
         (setq rtn (plist-put rtn p v))))
     rtn))
+
+(defun tide-get-file-buffer (file)
+  "Returns a buffer associated with a file. This will return the
+  current buffer if it matches `file'. This way we can support
+  temporary and indirect buffers."
+  (if (equal file (tide-buffer-file-name))
+      (current-buffer)
+    (find-file-noselect file)))
 
 (defun tide-response-success-p (response)
   (and response (equal (plist-get response :success) t)))
@@ -720,8 +728,8 @@ implementations.  When invoked with a prefix arg, jump to the type definition."
     (unless no-marker
       (ring-insert find-tag-marker-ring (point-marker)))
     (if reuse-window
-        (pop-to-buffer (find-file-noselect file) '((display-buffer-reuse-window display-buffer-same-window)))
-      (pop-to-buffer (find-file-noselect file)))
+        (pop-to-buffer (tide-get-file-buffer file) '((display-buffer-reuse-window display-buffer-same-window)))
+      (pop-to-buffer (tide-get-file-buffer file)))
     (tide-move-to-location (plist-get filespan :start))))
 
 (defalias 'tide-jump-back 'pop-tag-mark)
@@ -734,7 +742,7 @@ implementations.  When invoked with a prefix arg, jump to the type definition."
 (defun tide-jump-to-implementation-format-item (item)
   (let* ((file-name (plist-get item :file))
          (line (save-excursion
-                 (with-current-buffer (find-file-noselect file-name)
+                 (with-current-buffer (tide-get-file-buffer file-name)
                    (tide-move-to-location (plist-get item :start))
                    (replace-regexp-in-string "\n" "" (thing-at-point 'line)))))
          (file-pos (concat
@@ -988,10 +996,14 @@ Noise can be anything like braces, reserved keywords, etc."
 (defun tide-apply-code-edits (file-code-edits)
   (save-excursion
     (dolist (file-code-edit file-code-edits)
-      (with-current-buffer (find-file-noselect (plist-get file-code-edit :fileName))
-        (tide-format-regions (tide-apply-edits (plist-get file-code-edit :textChanges)))
-        (basic-save-buffer)
-        (run-hooks 'tide-post-code-edit-hook)))))
+      (let ((file (plist-get file-code-edit :fileName)))
+        (with-current-buffer (tide-get-file-buffer file)
+          (tide-format-regions (tide-apply-edits (plist-get file-code-edit :textChanges)))
+          ;; Saving won't work if the current buffer is temporary or an indirect
+          ;; buffer
+          (when (equal buffer-file-name file)
+            (basic-save-buffer))
+          (run-hooks 'tide-post-code-edit-hook))))))
 
 (defun tide-get-flycheck-errors-ids-at-point ()
   (-map #'flycheck-error-id (flycheck-overlay-errors-at (point))))
@@ -1066,7 +1078,7 @@ Noise can be anything like braces, reserved keywords, etc."
       (deactivate-mark)
       (tide-apply-code-edits (tide-plist-get response :body :edits))
       (-when-let (rename-location (tide-plist-get response :body :renameLocation))
-        (with-current-buffer (find-file-noselect (tide-plist-get response :body :renameFilename))
+        (with-current-buffer (tide-get-file-buffer (tide-plist-get response :body :renameFilename))
           (tide-move-to-location rename-location)
           (when (tide-can-rename-symbol-p)
             (tide-rename-symbol)))))))
@@ -1431,7 +1443,7 @@ number."
 (defun tide-rename-symbol-at-location (location new-symbol)
   (let ((file (plist-get location :file)))
     (save-excursion
-      (with-current-buffer (find-file-noselect file)
+      (with-current-buffer (tide-get-file-buffer file)
         (-each
             (-map (lambda (filespan)
                     (tide-move-to-location (plist-get filespan :start))
@@ -1443,7 +1455,10 @@ number."
               (goto-char marker)
               (delete-char (- (tide-plist-get filespan :end :offset) (tide-plist-get filespan :start :offset)))
               (insert new-symbol))))
-        (basic-save-buffer)
+        ;; Saving won't work if the current buffer is temporary or an indirect
+        ;; buffer
+        (when (equal buffer-file-name file)
+          (basic-save-buffer))
         (length (plist-get location :locs))))))
 
 (defun tide-read-new-symbol (old-symbol)

--- a/tide.el
+++ b/tide.el
@@ -186,11 +186,12 @@ above."
 (tide-def-permanent-buffer-local tide-buffer-dirty nil)
 (tide-def-permanent-buffer-local tide-buffer-tmp-file nil)
 (tide-def-permanent-buffer-local tide-active-buffer-file-name nil)
+(tide-def-permanent-buffer-local tide-require-manual-sync nil)
 
 (defvar tide-servers (make-hash-table :test 'equal))
 (defvar tide-response-callbacks (make-hash-table :test 'equal))
 
-(defvar tide-source-root-directory (file-name-directory (or load-file-name buffer-file-name)))
+(defvar tide-source-root-directory (file-name-directory (or load-file-name (tide-buffer-file-name))))
 (defvar tide-tsserver-directory (expand-file-name "tsserver" tide-source-root-directory))
 
 (defun tide-project-root ()
@@ -209,6 +210,17 @@ above."
 (defun tide-project-name ()
   (let ((full-path (directory-file-name (tide-project-root))))
     (concat (file-name-nondirectory full-path) "-" (substring (md5 full-path) 0 10))))
+
+(defun tide-buffer-file-name ()
+  "Returns either the path to the currently open file. This is
+  needed to support indirect buffers, as they don't set
+  `buffer-file-name' correctly."
+  (or (and (bound-and-true-p edit-indirect--overlay)
+           (buffer-file-name (overlay-buffer edit-indirect--overlay)))
+      (and (bound-and-true-p org-src--overlay)
+           (buffer-file-name (overlay-buffer org-src--overlay)))
+      buffer-file-name
+      (buffer-file-name (buffer-base-buffer))))
 
 ;;; Compatibility
 
@@ -629,34 +641,39 @@ If TIDE-TSSERVER-EXECUTABLE is set by the user use it.  Otherwise check in the n
     (_ standard-indent)))
 
 (defun tide-command:configure ()
-  (tide-send-command "configure" `(:hostInfo ,(emacs-version) :file ,buffer-file-name :formatOptions ,(tide-file-format-options))))
+  (tide-send-command "configure" `(:hostInfo ,(emacs-version) :file ,(tide-buffer-file-name) :formatOptions ,(tide-file-format-options))))
 
 (defun tide-command:projectInfo (cb &optional need-file-name-list)
-  (tide-send-command "projectInfo" `(:file ,buffer-file-name :needFileNameList ,need-file-name-list) cb))
+  (tide-send-command "projectInfo" `(:file ,(tide-buffer-file-name) :needFileNameList ,need-file-name-list) cb))
 
 (defun tide-command:openfile ()
   (tide-send-command "open"
-                     (append `(:file ,buffer-file-name)
-                             (let ((extension (upcase (file-name-extension buffer-file-name))))
-                               (if (member extension '("TS" "JS" "TSX" "JSX"))
-                                   `(:scriptKindName ,extension)
-                                 nil)))))
+                     (if tide-require-manual-sync
+                         `(:file
+                           ,(tide-buffer-file-name)
+                           ;; TODO: Set this according to a variable or an alist
+                           :scriptKindName "TS"
+                           :fileContent ,(buffer-string))
+                       (append `(:file ,(tide-buffer-file-name))
+                               (let ((extension (upcase (file-name-extension (tide-buffer-file-name)))))
+                                 (when (member extension '("TS" "JS" "TSX" "JSX"))
+                                   `(:scriptKindName ,extension)))))))
 
 (defun tide-command:closefile ()
-  (tide-send-command "close" `(:file ,buffer-file-name)))
+  (tide-send-command "close" `(:file ,(tide-buffer-file-name))))
 
 ;;; Jump to definition
 
 (defun tide-command:definition (cb)
   (tide-send-command
    "definition"
-   `(:file ,buffer-file-name :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset))
+   `(:file ,(tide-buffer-file-name) :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset))
    cb))
 
 (defun tide-command:typeDefinition (cb)
   (tide-send-command
    "typeDefinition"
-   `(:file ,buffer-file-name :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset))
+   `(:file ,(tide-buffer-file-name) :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset))
    cb))
 
 (defun tide-jump-to-definition (&optional arg)
@@ -681,7 +698,7 @@ implementations.  When invoked with a prefix arg, jump to the type definition."
 (defun tide-filespan-is-current-location-p (filespan)
   (let* ((location (plist-get filespan :start))
          (new-file-name (plist-get filespan :file)))
-    (and (string-equal new-file-name buffer-file-name)
+    (and (string-equal new-file-name (tide-buffer-file-name))
          (equal (tide-location-to-point location) (point)))))
 
 (defun tide-move-to-location (location)
@@ -712,7 +729,7 @@ implementations.  When invoked with a prefix arg, jump to the type definition."
 ;;; Jump to implementation
 
 (defun tide-command:implementation ()
-  (tide-send-command-sync "implementation" `(:file ,buffer-file-name :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset))))
+  (tide-send-command-sync "implementation" `(:file ,(tide-buffer-file-name) :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset))))
 
 (defun tide-jump-to-implementation-format-item (item)
   (let* ((file-name (plist-get item :file))
@@ -785,7 +802,7 @@ Noise can be anything like braces, reserved keywords, etc."
         (tide-jump-to-filespan navto-item)))))
 
 (defun tide-command:navto (type)
-  (tide-send-command-sync "navto" `(:file ,buffer-file-name :searchValue ,type :maxResultCount 100)))
+  (tide-send-command-sync "navto" `(:file ,(tide-buffer-file-name) :searchValue ,type :maxResultCount 100)))
 
 ;;; Eldoc
 
@@ -852,7 +869,7 @@ Noise can be anything like braces, reserved keywords, etc."
 (defun tide-command:signatureHelp (cb)
   (tide-send-command
    "signatureHelp"
-   `(:file ,buffer-file-name :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset))
+   `(:file ,(tide-buffer-file-name) :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset))
    (tide-on-response-success-callback response t
      (funcall cb (tide-annotate-signatures (plist-get response :body))))))
 
@@ -899,10 +916,10 @@ Noise can be anything like braces, reserved keywords, etc."
                    (list jsdoc))))))))
 
 (defun tide-command:quickinfo-old (cb)
-  (tide-send-command "quickinfo" `(:file ,buffer-file-name :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset)) cb))
+  (tide-send-command "quickinfo" `(:file ,(tide-buffer-file-name) :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset)) cb))
 
 (defun tide-command:quickinfo-full (cb)
-  (tide-send-command "quickinfo-full" `(:file ,buffer-file-name :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset)) cb))
+  (tide-send-command "quickinfo-full" `(:file ,(tide-buffer-file-name) :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset)) cb))
 
 (defun tide-command:quickinfo (cb)
   (tide-fallback-if-not-supported "quickinfo-full" tide-command:quickinfo-full tide-command:quickinfo-old cb))
@@ -947,7 +964,7 @@ Noise can be anything like braces, reserved keywords, etc."
     (setq tide-buffer-tmp-file nil)))
 
 (defun tide-command:reloadfile ()
-  (tide-send-command "reload" `(:file ,buffer-file-name :tmpfile ,buffer-file-name)))
+  (tide-send-command "reload" `(:file ,(tide-buffer-file-name) :tmpfile ,(tide-buffer-file-name))))
 
 (defun tide-handle-change (_beg _end _len)
   (setq tide-buffer-dirty t))
@@ -957,14 +974,14 @@ Noise can be anything like braces, reserved keywords, etc."
   ;; ways, one common example is the rename operation. Ensure that we
   ;; send the open command for the new file before using it as an
   ;; argument for any other command.
-  (unless (string-equal tide-active-buffer-file-name buffer-file-name)
+  (unless (string-equal tide-active-buffer-file-name (tide-buffer-file-name))
     (tide-configure-buffer))
   (when tide-buffer-dirty
     (setq tide-buffer-dirty nil)
     (when (not tide-buffer-tmp-file)
       (setq tide-buffer-tmp-file (make-temp-file "tide")))
     (write-region (point-min) (point-max) tide-buffer-tmp-file nil 'no-message)
-    (tide-send-command "reload" `(:file ,buffer-file-name :tmpfile ,tide-buffer-tmp-file))))
+    (tide-send-command "reload" `(:file ,(tide-buffer-file-name) :tmpfile ,tide-buffer-tmp-file))))
 
 ;;; Code-fixes
 
@@ -980,7 +997,7 @@ Noise can be anything like braces, reserved keywords, etc."
   (-map #'flycheck-error-id (flycheck-overlay-errors-at (point))))
 
 (defun tide-command:getCodeFixes ()
-  (tide-send-command-sync "getCodeFixes" `(:file ,(buffer-file-name) :startLine ,(tide-line-number-at-pos) :startOffset ,(tide-current-offset) :endLine ,(tide-line-number-at-pos) :endOffset ,(+ 1 (tide-current-offset)) :errorCodes ,(tide-get-flycheck-errors-ids-at-point))))
+  (tide-send-command-sync "getCodeFixes" `(:file ,((tide-buffer-file-name)) :startLine ,(tide-line-number-at-pos) :startOffset ,(tide-current-offset) :endLine ,(tide-line-number-at-pos) :endOffset ,(+ 1 (tide-current-offset)) :errorCodes ,(tide-get-flycheck-errors-ids-at-point))))
 
 (defun tide-get-fix-description (fix)
   (plist-get fix :description))
@@ -1019,13 +1036,13 @@ Noise can be anything like braces, reserved keywords, etc."
 (defun tide-command:getEditsForRefactor (refactor action)
   (tide-send-command-sync
    "getEditsForRefactor"
-   (append `(:refactor ,refactor :action ,action :file ,buffer-file-name)
+   (append `(:refactor ,refactor :action ,action :file ,(tide-buffer-file-name))
            (tide-location-or-range))))
 
 (defun tide-command:getApplicableRefactors ()
   (tide-send-command-sync
    "getApplicableRefactors"
-   (append `(:file ,buffer-file-name) (tide-location-or-range))))
+   (append `(:file ,(tide-buffer-file-name)) (tide-location-or-range))))
 
 (defun tide-get-refactor-description (refactor)
   (plist-get refactor :description))
@@ -1152,7 +1169,7 @@ Noise can be anything like braces, reserved keywords, etc."
 
 (defun tide-command:completions (prefix cb)
   (let* ((file-location
-          `(:file ,buffer-file-name :line ,(tide-line-number-at-pos) :offset ,(- (tide-current-offset) (length prefix)) :includeExternalModuleExports ,tide-completion-enable-autoimport-suggestions)))
+          `(:file ,(tide-buffer-file-name) :line ,(tide-line-number-at-pos) :offset ,(- (tide-current-offset) (length prefix)) :includeExternalModuleExports ,tide-completion-enable-autoimport-suggestions)))
     (when (not (tide-member-completion-p prefix))
       (setq file-location (plist-put file-location :prefix prefix)))
     (tide-send-command
@@ -1283,7 +1300,7 @@ Noise can be anything like braces, reserved keywords, etc."
 (defun tide-command:references ()
   (tide-send-command-sync
    "references"
-   `(:file ,buffer-file-name :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset))))
+   `(:file ,(tide-buffer-file-name) :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset))))
 
 (defun tide-annotate-line (reference line-text)
   (let ((start (1- (tide-plist-get reference :start :offset)))
@@ -1396,7 +1413,7 @@ number."
       node)))
 
 (defun tide-command:navbar ()
-  (tide-send-command-sync "navtree" `(:file ,buffer-file-name)))
+  (tide-send-command-sync "navtree" `(:file ,(tide-buffer-file-name))))
 
 (defun tide-imenu-index ()
   (let ((response (tide-command:navbar)))
@@ -1409,7 +1426,7 @@ number."
 ;;; Rename
 
 (defun tide-command:rename ()
-  (tide-send-command-sync "rename" `(:file ,buffer-file-name :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset))))
+  (tide-send-command-sync "rename" `(:file ,(tide-buffer-file-name) :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset))))
 
 (defun tide-rename-symbol-at-location (location new-symbol)
   (let ((file (plist-get location :file)))
@@ -1453,7 +1470,7 @@ number."
                (locs (tide-plist-get response :body :locs))
                (count 0))
           (cl-flet ((current-file-p (loc)
-                                    (file-equal-p (expand-file-name buffer-file-name)
+                                    (file-equal-p (expand-file-name (tide-buffer-file-name))
                                                   (plist-get loc :file))))
 
             ;; Saving current file will trigger a compilation
@@ -1518,7 +1535,7 @@ code-analysis."
 (defun tide-format-region (start end)
   (let ((response (tide-send-command-sync
                    "format"
-                   `(:file ,buffer-file-name
+                   `(:file ,(tide-buffer-file-name)
                            :line ,(tide-line-number-at-pos start)
                            :offset ,(tide-offset start)
                            :endLine ,(tide-line-number-at-pos end)
@@ -1556,7 +1573,8 @@ code-analysis."
     map))
 
 (defun tide-configure-buffer ()
-  (setq tide-active-buffer-file-name buffer-file-name)
+  (setq tide-active-buffer-file-name (tide-buffer-file-name))
+
   (tide-command:openfile)
   (tide-command:configure))
 
@@ -1571,20 +1589,36 @@ code-analysis."
   "Setup `tide-mode' in current buffer."
   (interactive)
 
-  ;; skip buffers where buffer-file-name is not defined, such as org-mode code
-  ;; blocks as they are fontified for html export
-  (if (stringp buffer-file-name)
-      (progn
-        (tide-start-server-if-required)
-        (tide-mode 1)
-        (set (make-local-variable 'eldoc-documentation-function)
-             'tide-eldoc-function)
-        (set (make-local-variable 'imenu-auto-rescan) t)
-        (set (make-local-variable 'imenu-create-index-function)
-             'tide-imenu-index)
+  ;; Indirect buffers embedded in other major modes such as those in org-mode or
+  ;; template languages have to be manually synchronized to tsserver. This might
+  ;; cause problems in files with lots of small blocks of TypeScript. In that
+  ;; case we should either add an ignore list or don't do anything at all when
+  ;; there are more than a certain amount of snippets.
+  (unless (stringp buffer-file-name)
+    (setq tide-require-manual-sync t))
 
-        (tide-configure-buffer))
-    (display-warning 'tide "A file backed buffer is required to start the tsserver.")))
+  (tide-start-server-if-required)
+  (tide-mode 1)
+  (set (make-local-variable 'eldoc-documentation-function)
+       'tide-eldoc-function)
+  (set (make-local-variable 'imenu-auto-rescan) t)
+  (set (make-local-variable 'imenu-create-index-function)
+       'tide-imenu-index)
+
+  (tide-configure-buffer)
+
+  ;; tsserver requires non-.ts files to be manually added to the files array in
+  ;; tsconfig.json, otherwise the file will be loaded as part of an 'inferred
+  ;; project'. This won't be necessary anymore after TypeScript allows defining
+  ;; custom file extensions. https://github.com/Microsoft/TypeScript/issues/8328
+  (when tide-require-manual-sync
+    (tide-command:projectInfo
+     (lambda (response)
+       (tide-on-response-success response nil
+         (when (string-prefix-p "/dev/null/inferredProject"
+                                (tide-plist-get response :body :configFileName))
+           (message (format "'%s' is not part of a project, add it to the files array in tsconfig.json"
+                            (tide-buffer-file-name)))))))))
 
 ;;;###autoload
 (define-minor-mode tide-mode
@@ -1629,7 +1663,7 @@ code-analysis."
                         (funcall cb `(:body (,result) :success t)))))))
       (tide-send-command
        "syntacticDiagnosticsSync"
-       `(:file ,buffer-file-name)
+       `(:file ,(tide-buffer-file-name))
        (lambda (response)
          (if (tide-response-success-p response)
              (setq result (plist-put result :syntaxDiag (plist-get response :body)))
@@ -1637,7 +1671,7 @@ code-analysis."
          (resolve)))
       (tide-send-command
        "semanticDiagnosticsSync"
-       `(:file ,buffer-file-name)
+       `(:file ,(tide-buffer-file-name))
        (lambda (response)
          (if (tide-response-success-p response)
              (setq result (plist-put result :semanticDiag (plist-get response :body)))
@@ -1728,7 +1762,7 @@ code-analysis."
 (defun tide-command:geterrForProject ()
   (tide-send-command
    "geterrForProject"
-   `(:file ,buffer-file-name :delay 0)))
+   `(:file ,(tide-buffer-file-name) :delay 0)))
 
 (defun tide-project-errors-buffer-name ()
   (format "*%s-errors*" (tide-project-name)))
@@ -1850,7 +1884,7 @@ code-analysis."
 (defun tide-command:documentHighlights (cb)
   (tide-send-command
    "documentHighlights"
-   `(:file ,buffer-file-name :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset) :filesToSearch (,buffer-file-name))
+   `(:file ,(tide-buffer-file-name) :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset) :filesToSearch (,(tide-buffer-file-name)))
    cb))
 
 (defface tide-hl-identifier-face
@@ -1965,7 +1999,7 @@ timeout."
 ;;; Compile On Save
 
 (defun tide-command:compileOnSaveEmitFile ()
-  (tide-send-command "compileOnSaveEmitFile" `(:file ,buffer-file-name)))
+  (tide-send-command "compileOnSaveEmitFile" `(:file ,(tide-buffer-file-name))))
 
 (defun tide-compile-file ()
   "Compiles the current file"


### PR DESCRIPTION
This allows tide to be used in e.g. template files. The only caveat is that the file has to be manually added to tsconfig.json, as the globs in the include array ignore non-typescript files (see https://github.com/Microsoft/TypeScript/issues/8328). Otherwise the file will be added to an inferred project with default compiler settings. This fixes #198.