### PR TITLE
Prototype for new direct refactorings.

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -1024,6 +1024,19 @@ Noise can be anything like braces, reserved keywords, etc."
           applicable-refactor-infos)))
     (tide-select-item-from-list "Select refactor: " available-refactors #'tide-get-refactor-description (tide-can-use-popup-p 'refactor))))
 
+(defun tide-refactor-class ()
+  (interactive)
+  (tide-apply-refactor '(:action "convert" :refactor "Convert to ES2015 class")))
+
+(defun tide-refactor-extract-function ()
+  (interactive)
+  (tide-apply-refactor '(:action "function_scope_1" :refactor "Extract Symbol")))
+
+(defun tide-refactor-extract-internal-function ()
+  (interactive)
+  (tide-apply-refactor '(:action "function_scope_0" :refactor "Extract Symbol")))
+
+my-test
 (defun tide-apply-refactor (selected)
   (let ((response (tide-command:getEditsForRefactor (plist-get selected :refactor) (plist-get selected :action))))
     (tide-on-response-success response nil


### PR DESCRIPTION
This PR is **not** meant to be merged at this point, but just meant to have something concrete to discuss around.

As discussed earlier, `tide-refactor` quickly becomes a annoying stepping-stone which one may want to avoid when you want to activate a known refactoring which you know should be applicable at the current point in the document. 

As such, it would be nice to have some direct commands/functions which you can apply key-bindings to, if you want to trigger this refactorings directly.

This PR contains a very minimal proof of concept for how this can be done. These have been created by inspecting the response from `tsserver` after triggering the `tide-refactor` command.

I realize this code probably needs some additional cleanup, verification and possibly also user-feedback if a refactoring is found not to be applicable at the current location..

That said, does anyone have any comment to the approach chosen here? Is the naming-convention OK? I for instance observe already now that it differs from `tide-rename-symbol` and `tide-fix`.  Does anyone have a better suggestion?

cc: @ananthakumaran @lddubeau 