### PR TITLE
defcustom to turn off sorting completions by kind

### DIFF
--- a/tide-tests.el
+++ b/tide-tests.el
@@ -32,7 +32,7 @@
   (should (equal "this\nis\nfour\nlines"
                  (tide-normalize-lineshift "this\nis\r\nfour\nlines"))))
 
-(ert-deftest completions-get-sorted-by-kind ()
+(ert-deftest completions-get-sorted ()
   "Tests that completion candidates get sorted by kind."
   (let ((mock-completions
          '(
@@ -58,28 +58,8 @@
            (:name "DOMError" :kind "interface" :kindModifiers "declare"))
          ))
     (should (-same-items?
-             (-sort 'tide-compare-completions-by-kind mock-completions)
+             (-sort 'tide-compare-completions mock-completions)
              sorted-completions))))
-
-(ert-deftest completions-get-sorted-by-case ()
-  "Tests that completion candidates get sorted by case."
-  (let ((mock-completions
-         '(
-           (:name "a" :kind "var" :kindModifiers "declare")
-           (:name "c" :kind "var" :kindModifiers)
-           (:name "b" :kind "function" :kindModifiers)
-           (:name "D" :kind "const" :kindModifiers)))
-        (sorted-completions
-         '(
-           (:name "D" :kind "const" :kindModifiers)
-           (:name "a" :kind "var" :kindModifiers "declare")
-           (:name "b" :kind "function" :kindModifiers)
-           (:name "c" :kind "var" :kindModifiers))
-         ))
-    (should (-same-items?
-             (-sort 'tide-compare-completions-by-case mock-completions)
-             sorted-completions))))
-
 
 (provide 'tide-tests)
 

--- a/tide-tests.el
+++ b/tide-tests.el
@@ -32,7 +32,7 @@
   (should (equal "this\nis\nfour\nlines"
                  (tide-normalize-lineshift "this\nis\r\nfour\nlines"))))
 
-(ert-deftest completions-get-sorted ()
+(ert-deftest completions-get-sorted-by-kind ()
   "Tests that completion candidates get sorted by kind."
   (let ((mock-completions
          '(
@@ -58,8 +58,28 @@
            (:name "DOMError" :kind "interface" :kindModifiers "declare"))
          ))
     (should (-same-items?
-             (-sort 'tide-compare-completions mock-completions)
+             (-sort 'tide-compare-completions-by-kind mock-completions)
              sorted-completions))))
+
+(ert-deftest completions-get-sorted-by-case ()
+  "Tests that completion candidates get sorted by case."
+  (let ((mock-completions
+         '(
+           (:name "a" :kind "var" :kindModifiers "declare")
+           (:name "c" :kind "var" :kindModifiers)
+           (:name "b" :kind "function" :kindModifiers)
+           (:name "D" :kind "const" :kindModifiers)))
+        (sorted-completions
+         '(
+           (:name "D" :kind "const" :kindModifiers)
+           (:name "a" :kind "var" :kindModifiers "declare")
+           (:name "b" :kind "function" :kindModifiers)
+           (:name "c" :kind "var" :kindModifiers))
+         ))
+    (should (-same-items?
+             (-sort 'tide-compare-completions-by-case mock-completions)
+             sorted-completions))))
+
 
 (provide 'tide-tests)
 

--- a/tide.el
+++ b/tide.el
@@ -88,6 +88,11 @@ above."
   :type 'hook
   :group 'tide)
 
+(defcustom tide-sort-completions-by-kind nil
+  "Whether completions should be sorted by kind"
+  :type 'boolean
+  :group 'tide)
+
 (defvar tide-format-options '()
   "Format options plist.")
 
@@ -1126,12 +1131,13 @@ Noise can be anything like braces, reserved keywords, etc."
        (put-text-property 0 1 'file-location file-location name)
        (put-text-property 0 1 'completion completion name)
        name))
-   (-sort
-    'tide-compare-completions
-    (-filter
-     (lambda (completion)
-       (string-prefix-p prefix (plist-get completion :name)))
-     completions))))
+   (let ((filtered
+          (-filter (lambda (completion)
+                     (string-prefix-p prefix (plist-get completion :name)))
+                   completions)))
+     (if tide-sort-completions-by-kind
+         (-sort 'tide-compare-completions filtered)
+       filtered))))
 
 (defun tide-command:completions (prefix cb)
   (let* ((file-location

--- a/tide.el
+++ b/tide.el
@@ -88,9 +88,11 @@ above."
   :type 'hook
   :group 'tide)
 
-(defcustom tide-sort-completions-by-kind nil
-  "Whether completions should be sorted by kind"
-  :type 'boolean
+(defcustom tide-sort-completions 'default
+  "How to sort completions. The default from Typescript is case-insensitive."
+  :type '(choice (const :tag "Default" default)
+                 (const :tag "Case-sensitive" case)
+                 (const :tag "Kind" kind))
   :group 'tide)
 
 (defvar tide-format-options '()
@@ -1106,7 +1108,7 @@ Noise can be anything like braces, reserved keywords, etc."
       ))
    100))
 
-(defun tide-compare-completions (completion-a completion-b)
+(defun tide-compare-completions-by-kind (completion-a completion-b)
   "Compare COMPLETION-A and COMPLETION-B based on their kind."
   (let ((modifier-a (plist-get completion-a :kindModifiers))
         (modifier-b (plist-get completion-b :kindModifiers)))
@@ -1114,6 +1116,12 @@ Noise can be anything like braces, reserved keywords, etc."
         (< (tide-completion-rank completion-a) (tide-completion-rank completion-b))
       ;; Rank declarations lower than variables
       (string-equal modifier-b "declare"))))
+
+(defun tide-compare-completions-by-case (completion-a completion-b)
+  "Compare COMPLETION-A and COMPLETION-B based on their names."
+  (let ((name-a (plist-get completion-a :name))
+        (name-b (plist-get completion-b :name)))
+    (string-lessp name-a name-b)))
 
 (defun tide-completion-prefix ()
   (company-grab-symbol-cons "\\." 1))
@@ -1135,9 +1143,10 @@ Noise can be anything like braces, reserved keywords, etc."
           (-filter (lambda (completion)
                      (string-prefix-p prefix (plist-get completion :name)))
                    completions)))
-     (if tide-sort-completions-by-kind
-         (-sort 'tide-compare-completions filtered)
-       filtered))))
+     (cl-case tide-sort-completions
+       (kind (-sort 'tide-compare-completions-by-kind filtered))
+       (case (-sort 'tide-compare-completions-by-case filtered))
+       (default filtered)))))
 
 (defun tide-command:completions (prefix cb)
   (let* ((file-location


### PR DESCRIPTION
Fixes #214 by adding a custom variable. Ideally the sorting would just be removed, but some people may prefer to have it on.

Note that the variable defaults to `nil`, however.