### PR TITLE
Skip first layer when building a hierarchical imenu index

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -1396,10 +1396,10 @@ number."
 (defun tide-imenu-index ()
   (let ((response (tide-command:navbar)))
     (tide-on-response-success response nil
-      (let ((navtree (plist-get response :body)))
+      (let ((children (tide-plist-get response :body :childItems)))
         (if tide-imenu-flatten
-            (-flatten (-map #'tide-build-flat-imenu-index (plist-get navtree :childItems)))
-          (list (tide-build-imenu-index navtree)))))))
+            (-flatten (-map #'tide-build-flat-imenu-index children))
+          (mapcar #'tide-build-imenu-index children))))))
 
 ;;; Rename
 


### PR DESCRIPTION
Fixes #217

I'm not familiar with the `tsserver` methods, but it seems like the navtree hierarchy always has a single element as its root.