### PR TITLE
Derive project-errors and references modes from special-mode

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -1261,15 +1261,12 @@ Noise can be anything like braces, reserved keywords, etc."
     (define-key map (kbd "p") #'tide-find-previous-reference)
     (define-key map (kbd "C-m") #'tide-goto-reference)
     (define-key map [mouse-1] #'tide-goto-reference)
-    (define-key map (kbd "q") #'quit-window)
     map))
 
-(define-derived-mode tide-references-mode nil "tide-references"
+(define-derived-mode tide-references-mode special-mode "tide-references"
   "Major mode for tide references list.
 
 \\{tide-references-mode-map}"
-  (use-local-map tide-references-mode-map)
-  (setq buffer-read-only t)
   (setq next-error-function #'tide-next-reference-function))
 
 (defun tide-command:references ()
@@ -1820,15 +1817,12 @@ code-analysis."
     (define-key map (kbd "n") #'tide-find-next-error)
     (define-key map (kbd "p") #'tide-find-previous-error)
     (define-key map (kbd "C-m") #'tide-goto-error)
-    (define-key map (kbd "q") #'quit-window)
     map))
 
-(define-derived-mode tide-project-errors-mode nil "tide-project-errors"
+(define-derived-mode tide-project-errors-mode special-mode "tide-project-errors"
   "Major mode for tide project-errors list.
 
 \\{tide-project-errors-mode-map}"
-  (use-local-map tide-project-errors-mode-map)
-  (setq buffer-read-only t)
   (setq next-error-function #'tide-next-error-function))
 
 ;;;###autoload


### PR DESCRIPTION
Closes #216 

I took out the read-only declaration, the `quit-window` binding, and the `use-local-map` call. The first two are definitely taken care of by special-mode; the last one I think all minor modes do. I tested the changes on 25.2 and everything worked the same