### PR TITLE
Fix tide-command:getCodeFixes failing with getting file name

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -1016,7 +1016,7 @@ Noise can be anything like braces, reserved keywords, etc."
   (-map #'flycheck-error-id (flycheck-overlay-errors-at (point))))
 
 (defun tide-command:getCodeFixes ()
-  (tide-send-command-sync "getCodeFixes" `(:file ,((tide-buffer-file-name)) :startLine ,(tide-line-number-at-pos) :startOffset ,(tide-current-offset) :endLine ,(tide-line-number-at-pos) :endOffset ,(+ 1 (tide-current-offset)) :errorCodes ,(tide-get-flycheck-errors-ids-at-point))))
+  (tide-send-command-sync "getCodeFixes" `(:file ,(tide-buffer-file-name) :startLine ,(tide-line-number-at-pos) :startOffset ,(tide-current-offset) :endLine ,(tide-line-number-at-pos) :endOffset ,(+ 1 (tide-current-offset)) :errorCodes ,(tide-get-flycheck-errors-ids-at-point))))
 
 (defun tide-get-fix-description (fix)
   (plist-get fix :description))


### PR DESCRIPTION
I wasn't able to use `tide-fix` with latest master, this PR fixes it but I have no knowledge in eslip/lisp so I have no idea what I'm doing 🤔 