### PR TITLE
verify filename before applying highlights

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -1960,7 +1960,10 @@ highlights from previously highlighted identifier."
 
 (defun tide--hl-highlight (response)
   "Highlight all instances of the identifier under point."
-  (let ((references (plist-get (car (plist-get response :body)) :highlightSpans)))
+  (-when-let* ((item (-first (lambda (item)
+                               (equal (tide-buffer-file-name) (plist-get item :file)))
+                             (plist-get response :body)))
+               (references (plist-get item :highlightSpans)))
     (-each references
       (lambda (reference)
         (let* ((kind (plist-get reference :kind))


### PR DESCRIPTION
fixes #236 

@bdowning I am not able to reproduce it locally with version `2.8.0-dev.20180127`. But I guess this should fix/workaround the bug. Could it test it out?