### PR TITLE
Support tsconfig with "extends" field without extension.

### DIFF
--- a/test/tsconfig-no-extension.json
+++ b/test/tsconfig-no-extension.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ES7"
+  },
+  "extends": "./base"
+}

--- a/tide-tests.el
+++ b/tide-tests.el
@@ -88,6 +88,9 @@
   (should (tide-plist-equal '(:compilerOptions (:target "ES7" :sourceMap t) :extends "./base.json" :compileOnSave t)
                  (tide-load-tsconfig "test/tsconfig.json" '())))
 
+  (should (tide-plist-equal '(:compilerOptions (:target "ES7" :sourceMap t) :extends "./base" :compileOnSave t)
+                            (tide-load-tsconfig "test/tsconfig-no-extension.json" '())))
+
   (should (tide-plist-equal '(:compileOnSave t :compilerOptions (:target "ES6" :sourceMap t))
                  (tide-load-tsconfig "test/base.json" '())))
 


### PR DESCRIPTION
The `"extends"` field in `tsconfig.json` files may specify a file name
with or without extension. E.g. if the file `"./base.json"` exists then
a `tsconfig.json` with:

```
"extends": "./base"
```

is equivalent to a tsconfig.json with:

```
"extends": "./base.json"
```