### PR TITLE
Recenter screen after jump

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -174,7 +174,7 @@ above."
   :type '(choice (const "TS") (const "TSX") (const "JS")(const  "JSX"))
   :group 'tide)
 
-(defcustom tide-recenter-after-jump nil
+(defcustom tide-recenter-after-jump t
   "Recenter buffer after jumping to definition"
   :type 'boolean
   :group 'tide)

--- a/tide.el
+++ b/tide.el
@@ -721,7 +721,7 @@ implementations.  When invoked with a prefix arg, jump to the type definition."
               (tide-on-response-success response
                 (-when-let (filespan (car (plist-get response :body)))
                   ;; if we're still at the same location...
-                  ;; maybe we're a abstract member which has impementations?
+                  ;; maybe we're a abstract member which has implementations?
                   (if (and (not arg)
                            (tide-filespan-is-current-location-p filespan))
                       (tide-jump-to-implementation)

--- a/tide.el
+++ b/tide.el
@@ -757,7 +757,8 @@ implementations.  When invoked with a prefix arg, jump to the type definition."
     (if reuse-window
         (pop-to-buffer (tide-get-file-buffer file) '((display-buffer-reuse-window display-buffer-same-window)))
       (pop-to-buffer (tide-get-file-buffer file)))
-    (tide-move-to-location (plist-get filespan :start))))
+    (tide-move-to-location (plist-get filespan :start))
+    (recenter)))
 
 (defalias 'tide-jump-back 'pop-tag-mark)
 


### PR DESCRIPTION
Recenter call added in `tide-jump-to-filespan`. However, condition is not checked whether the definition line was already in view or not.