### PR TITLE
Add tide-add-tslint-disable-next-line

### DIFF
--- a/tide-tests.el
+++ b/tide-tests.el
@@ -22,6 +22,7 @@
 
 (require 'tide)
 (require 'dash)
+(require 'cl)
 
 (defun tide-plist-equal (a b)
   (and (listp a) (listp b)
@@ -123,6 +124,65 @@
   (should-error (tide-load-tsconfig "test/loop.json" '()))
 
   (should-error (tide-load-tsconfig "test/notfound.json" '())))
+
+;; Adapted from jdee-mode's test suite.
+(defmacro test-with-temp-buffer (content &rest body)
+  "Fill a temporary buffer with `CONTENT' and eval `BODY' in it."
+  (declare (debug t)
+           (indent 1))
+  `(with-temp-buffer
+     (insert ,content)
+     (tide-mode)
+     (goto-char (point-min))
+     ;; We need this so that tests that simulate user actions operate on the right buffer.
+     (switch-to-buffer (current-buffer))
+     ,@body))
+
+(defun test-tide-add-tslint-disable-next-line (mock initial goto expected)
+  (test-with-temp-buffer
+   initial
+   (search-forward goto nil t)
+   (goto-char (match-beginning 0))
+   (cl-letf (((symbol-function 'tide-get-flycheck-errors-ids-at-point)
+              (lambda () mock)))
+     (tide-add-tslint-disable-next-line)
+     (should (string= (buffer-string) expected)))))
+
+(ert-deftest tide-add-tslint-disable-next-line/no-errors ()
+  "If there are no flycheck errors at point, it should be a no-op."
+  (let ((initial "// tslint:disable-next-line:previous\nconst x = 1;\nconst y = 2;\n"))
+    (test-tide-add-tslint-disable-next-line
+     ()
+     initial
+     "const y"
+     initial)))
+
+;; The first line of the buffer consitutes an edge condition. An
+;; earlier version of the function failed in this case.
+(ert-deftest tide-add-tslint-disable-next-line/first-line ()
+  "Create a new tslint flag if needed. (First line of buffer)"
+  (let ((initial "const x = 1;\nconst y = 2;\n"))
+    (test-tide-add-tslint-disable-next-line
+     '("err1" "err2")
+     initial
+     "const x"
+     (concat "// tslint:disable-next-line:err1 err2\n" initial))))
+
+(ert-deftest tide-add-tslint-disable-next-line/subsequent-lines ()
+  "Create a new tslint flag if needed. (Subsequent lines of buffer)"
+  (test-tide-add-tslint-disable-next-line
+   '("err1" "err2")
+   "const x = 1;\nconst y = 2;\n"
+   "const y"
+   "const x = 1;\n// tslint:disable-next-line:err1 err2\nconst y = 2;\n"))
+
+(ert-deftest tide-add-tslint-disable-next-line/adds ()
+  "If there was already a disable-next-line flag, add to it."
+  (test-tide-add-tslint-disable-next-line
+   '("err1" "err2")
+   "// tslint:disable-next-line:previous\nconst x = 1;\nconst y = 2;\n"
+   "const x"
+   "// tslint:disable-next-line:previous err1 err2\nconst x = 1;\nconst y = 2;\n"))
 
 (provide 'tide-tests)
 

--- a/tide.el
+++ b/tide.el
@@ -1187,6 +1187,49 @@ in the file that are similar to the error at point."
            (tide-select-refactor body))
         (message "No refactors available.")))))
 
+;;; Disable tslint warnings
+
+(defconst tide-tslint-disable-next-line-regexp
+  "\\s *//\\s *tslint\\s *:\\s *disable-next-line\\s *:\\(.*\\)"
+  "Regexp matching a tslint flag disabling rules on the next line.")
+
+(defun tide-add-tslint-disable-next-line ()
+  "Add a tslint flag to disable rules generating errors at point.
+
+This function adds or modifies a flag of this form to the
+previous line:
+
+  // tslint:disable-next-line:[rule1] [rule2] [...]
+
+The line will be indented according to the current indentation
+settings.  This function generates rule1, rule2 to cover all the
+errors present at point.
+
+If the previous line does not already contain a disable-next-line
+flag, a new line is added to hold the new flag.  If the previous
+line already contains a disable-next-line flag, the rule is added
+to the flag.  Note that this function does not preserve the
+formatting of the already existing flag.  The resulting flag will
+always be formatted as described above."
+  (interactive)
+  (let ((error-ids (delq nil (tide-get-flycheck-errors-ids-at-point)))
+        (start (point)))
+    (when error-ids
+      (save-excursion
+        (if (and (eq 0 (forward-line -1))
+                 (looking-at tide-tslint-disable-next-line-regexp))
+            ;; We'll update the old flag.
+            (let ((old-list (split-string (match-string 1))))
+              (delete-region (point) (point-at-eol))
+              (setq error-ids (append old-list error-ids)))
+          ;; We'll create a new flag.
+          (goto-char start)
+          (beginning-of-line)
+          (open-line 1))
+        (insert "// tslint:disable-next-line:"
+                (string-join error-ids " "))
+        (typescript-indent-line)))))
+
 ;;; Auto completion
 
 (defun tide-completion-annotation (name)


### PR DESCRIPTION
This is not complete yet because I've not added a test for it to the test suite, but I've been sitting on this since last October. It is high time it be integrated *somewhere*.

This essentially adds a function that allows for automatically turning off `tslint` warnings. The gory details are in the docstring for the new function, but here is an example:

```
if (something.foo("blah"))
```

If you have 5 `tslint` rules giving you warnings at `foo` and you move your point there and issue `tide-add-tslint-disable-next-line` then your code will become:

```
// tslint:disable-next-line:[rule1] [rule2] [rule3] [rule4] [rule5]
if (something.foo("blah"))
```

I feel the function I'm adding here is more `tide`-y than `typescript-mode`-y but maybe there's a good argument to be made that it belongs to `typescript-mode` rather than `tide`.