### PR TITLE
Fix use-package config to only load Tide for TS/JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ true.
 (use-package tide
   :ensure t
   :after (typescript-mode company flycheck)
-  :config (tide-setup)
-  :hook ((typescript-mode . tide-hl-identifier-mode)
+  :hook ((typescript-mode . tide-setup)
+         (typescript-mode . tide-hl-identifier-mode)
          (before-save . tide-format-before-save)))
 ```
 


### PR DESCRIPTION
Even with the deferred loading, the original use-package example would enable `tide` for _every_ buffer, along with the hook for formatting before save. This would result in non-JS/TS files being corrupted when saving changes, for example:

Before saving the file:

        (add-to-list 'auto-mode-alist '("\\.jsx\\'" . web-mode))

After saving the file:

        (add - to - list 'auto - mode - alist '(  "\\.jsx\\'" . web - mode ) )

It might not happen all the time (possibly it only happens in conjunction with other settings, as it never occurred when first trying it out). It took a few days to realise my example here was destroying my init.el. :)