### PR TITLE
support move-to-file refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,15 @@ Whether completions should be sorted by kind.
 
 Format options plist.
 
+**tide-user-preferences** `'(:includeCompletionsForModuleExports t :includeCompletionsWithInsertText t :allowTextChangesInNewFiles t)
+`
+
+User preference plist used on the configure request.
+
+Check
+https://github.com/Microsoft/TypeScript/blob/17eaf50b73c1355d2fd15bdc3912aa64a73483dd/src/server/protocol.ts#L2684
+for the full list of available options.
+
 **tide-completion-ignore-case** `nil`
 
 CASE will be ignored in completion if set to non-nil.
@@ -314,3 +323,4 @@ this variable to non-nil value for Javascript buffers using `setq-local` macro.
 **tide-hl-identifier-idle-time** `0.5`
 
 How long to wait after user input before highlighting the current identifier.
+

--- a/tide.el
+++ b/tide.el
@@ -773,7 +773,7 @@ implementations.  When invoked with a prefix arg, jump to the type definition."
       (widen)
       (goto-char (point-min))
       (forward-line (1- line)))
-    (when (not (eql 1 (point)))
+    (when (not (and (= offset 0) (= line 0)))
       (forward-char (1- offset)))))
 
 (defun tide-location-to-point (location)

--- a/tide.el
+++ b/tide.el
@@ -773,7 +773,7 @@ implementations.  When invoked with a prefix arg, jump to the type definition."
       (widen)
       (goto-char (point-min))
       (forward-line (1- line)))
-    (when (not (and (= offset 0) (= line 0)))
+    (when (not (eql 1 (point)))
       (forward-char (1- offset)))))
 
 (defun tide-location-to-point (location)


### PR DESCRIPTION
This [refactor](https://code.visualstudio.com/updates/v1_24#_move-to-new-file-refactoring) is only enabled if `allowTextChangesInNewFiles` flag is
set on the configure request. Handle code edits for non existent file.