### PR TITLE
Make tide-nav filter customizable

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -113,6 +113,11 @@ above."
   :type 'boolean
   :group 'tide)
 
+(defcustom tide-nav-item-filter 'types
+  "The filter for items returned by tide-nav"
+  :type '(choice (const none) (const types))
+  :group 'tide)
+
 (defface tide-file
   '((t (:inherit dired-header)))
   "Face for file names in references output."
@@ -854,10 +859,11 @@ Noise can be anything like braces, reserved keywords, etc."
                     (let ((response (tide-command:navto prefix)))
                       (tide-on-response-success response
                         (-when-let (navto-items (plist-get response :body))
-                          (setq navto-items
-                                (-filter
-                                 (lambda (navto-item) (member (plist-get navto-item :kind) '("class" "interface" "type" "enum")))
-                                 navto-items))
+                          (if (eq tide-nav-item-filter 'types)
+                              (setq navto-items
+                                    (-filter
+                                     (lambda (navto-item) (member (plist-get navto-item :kind) '("class" "interface" "type" "enum")))
+                                     navto-items)))
                           (setq last-completions navto-items)
                           (-map (lambda (navto-item) (plist-get navto-item :name))
                                 navto-items)))))


### PR DESCRIPTION
Based on the discussion in #265, I made a simple customize entry for tide-nav's item filtering.

It's not fancy right now, for two reasons:
1. I'm not confident with defcustom (or emacs develoment in general), so I tried the simplest thing that would work.
2. I think that All and Types are the only two choices that make sense, so something fancier like a big checklist would only confuse people. In addition, implementing All by checking the entire checklist would also be slow, since it would be `member` of a medium-ish list filtered over a large list.

The biggest obstacle, however, is (1), so please do suggest improvements if you see them.