### PR TITLE
tide-references: make entire line clickable

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -1521,7 +1521,7 @@ This function is used for the basic completions sorting."
     (put-text-property start end 'face 'tide-match line-text)
     (put-text-property start end 'mouse-face 'highlight line-text)
     (put-text-property start end 'help-echo "mouse-1: Visit the reference." line-text)
-    (put-text-property start end 'tide-reference reference line-text)))
+    (put-text-property 0 (length line-text) 'tide-reference reference line-text)))
 
 (defun tide-insert-references (references)
   "Create a buffer with the given REFERENCES.


### PR DESCRIPTION
Note that the presentation doesn't change; only the symbol in question is highlighted, but you can now click anywhere in the line to jump to the reference location.

I made this change for two reasons:
1. I am bad at clicking things, especially small ones. 
2. I use hiwin to grey out non-active windows, which cancels tide-reference's highlights when it's not active.

However, I think this change will benefit everybody by making the click target bigger.