### PR TITLE
WIP: server management

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ point.
 
 <kbd>M-x tide-organize-imports</kbd> Organize imports in the file.
 
+<kbd>M-x tide-list-servers</kbd> List the `tsserver` processes launched by
+tide.
+
 ### Features
 
 * ElDoc
@@ -323,4 +326,3 @@ this variable to non-nil value for Javascript buffers using `setq-local` macro.
 **tide-hl-identifier-idle-time** `0.5`
 
 How long to wait after user input before highlighting the current identifier.
-

--- a/test/trivial.ts
+++ b/test/trivial.ts
@@ -1,0 +1,1 @@
+const foo = 1;

--- a/tide.el
+++ b/tide.el
@@ -2384,18 +2384,8 @@ timeout."
                     project-name ,project-name
                     action tide--list-servers-verify-setup))
                  (name (process-name p))
-                 (buf-label (if (buffer-live-p buf)
-                                `(,(buffer-name buf)
-                                  face link
-                                  help-echo ,(format-message
-                                              "Visit buffer `%s'"
-                                              (buffer-name buf))
-                                  follow-link t
-                                  process-buffer ,buf
-                                  action process-menu-visit-buffer)
-                              "--"))
                  (cmd (mapconcat 'identity (process-command p) " ")))
-            (push (list p (vector project-name-label name status buf-label cmd))
+            (push (list p (vector project-name-label name status cmd))
                   tabulated-list-entries)))))))
 
 (defun tide--server-list-kill-server ()
@@ -2417,7 +2407,6 @@ timeout."
   (setq tabulated-list-format [("Project Name" 15 t)
                                ("Process" 15 t)
 			       ("Status"   7 t)
-			       ("Buffer"  15 t)
 			       ("Command"  0 t)])
   (setq tabulated-list-sort-key (cons "Project Name" nil))
   (add-hook 'tabulated-list-revert-hook 'tide--list-servers-refresh nil t)

--- a/tide.el
+++ b/tide.el
@@ -396,15 +396,14 @@ ones and overrule settings in the other lists."
 
 (defun tide-any-buffer (project-name fn)
   "Callback FN for the first buffer within PROJECT-NAME with tide-mode enabled."
-  (let* ((buffer (-any (lambda (buffer)
-                         (with-current-buffer buffer
-                           (when (and (bound-and-true-p tide-mode)
-                                      (equal (tide-project-name) project-name))
-                             buffer)))
-                       (buffer-list))))
-    (when buffer
-      (with-current-buffer buffer
-        (funcall fn)))))
+  (-when-let (buffer (-any (lambda (buffer)
+                             (with-current-buffer buffer
+                               (when (and (bound-and-true-p tide-mode)
+                                          (equal (tide-project-name) project-name))
+                                 buffer)))
+                           (buffer-list)))
+    (with-current-buffer buffer
+      (funcall fn))))
 
 (defun tide-line-number-at-pos (&optional pos)
   (let ((p (or pos (point))))

--- a/tide.el
+++ b/tide.el
@@ -2368,13 +2368,25 @@ timeout."
     (dolist (p tsservers)
       (let* ((project-name (process-get p 'project-name))
              (pid (process-id p))
-             (cpu (alist-get 'pcpu (process-attributes pid))))
+             (cpu
+              ;; alist-get is missing from Emacs prior to version 25. This code should be
+              ;; simplified to just call alist-get once we no longer support versions that
+              ;; lack it.
+              (if (functionp 'alist-get)
+                  (alist-get 'pcpu (process-attributes pid))
+                (cdr (assq 'pcpu (process-attributes pid))))))
         (push (list p
                     (vector
                      `(,project-name
                        face link
-                       help-echo ,(format-message "Verify setup of `%s'"
-                                                  project-name)
+                       help-echo
+                       ;; format-message is missing from Emacs prior to 25. This code should
+                       ;; be simplfied to just call format-message once we no longer support
+                       ;; versions that lack it.
+                       ,(if (functionp 'format-message)
+                            (format-message "Verify setup of `%s'"
+                                            project-name)
+                          (concat "Verify setup of `" project-name "'"))
                        follow-link t
                        project-name ,project-name
                        action tide--list-servers-verify-setup)

--- a/tide.el
+++ b/tide.el
@@ -289,6 +289,10 @@ this variable to non-nil value for Javascript buffers using `setq-local' macro."
               (,old ,cb))
           (funcall ,cb response))))))
 
+(defun tide--emacs-at-least (version)
+  "Return t if Emacs is at least at version VERSION.  Return nil, otherwise."
+  (not (version< emacs-version version)))
+
 ;;; Helpers
 
 (defun tide-safe-json-read-file (filename)
@@ -2369,10 +2373,7 @@ timeout."
       (let* ((project-name (process-get p 'project-name))
              (pid (process-id p))
              (cpu
-              ;; alist-get is missing from Emacs prior to version 25. This code should be
-              ;; simplified to just call alist-get once we no longer support versions that
-              ;; lack it.
-              (if (functionp 'alist-get)
+              (if (tide--emacs-at-least "25")
                   (alist-get 'pcpu (process-attributes pid))
                 (cdr (assq 'pcpu (process-attributes pid))))))
         (push (list p
@@ -2380,12 +2381,8 @@ timeout."
                      `(,project-name
                        face link
                        help-echo
-                       ;; format-message is missing from Emacs prior to 25. This code should
-                       ;; be simplfied to just call format-message once we no longer support
-                       ;; versions that lack it.
-                       ,(if (functionp 'format-message)
-                            (format-message "Verify setup of `%s'"
-                                            project-name)
+                       ,(if (tide--emacs-at-least "25")
+                            (format-message "Verify setup of `%s'" project-name)
                           (concat "Verify setup of `" project-name "'"))
                        follow-link t
                        project-name ,project-name

--- a/tide.el
+++ b/tide.el
@@ -2393,7 +2393,7 @@ timeout."
                      ;; Sometimes the CPU usage value is NaN (which Emacs represents
                      ;; as 0.0e+NaN), for whatever reason. We cannot pass this value
                      ;; to round so we put "--" for the column value.
-                     (if (equal cpu 0.0e+NaN)
+                     (if (isnan cpu)
                          "--"
                        (number-to-string (round cpu)))
                      (case tide--server-list-mode-last-column

--- a/tide.el
+++ b/tide.el
@@ -394,14 +394,13 @@ ones and overrule settings in the other lists."
                    (equal (tide-project-name) project-name))
           (funcall fn))))))
 
-(defun tide-any-buffer (project-name fn)
+(defun tide-first-buffer (project-name fn)
   "Callback FN for the first buffer within PROJECT-NAME with tide-mode enabled."
-  (-when-let (buffer (-any (lambda (buffer)
+  (-when-let (buffer (-first (lambda (buffer)
                              (with-current-buffer buffer
-                               (when (and (bound-and-true-p tide-mode)
-                                          (equal (tide-project-name) project-name))
-                                 buffer)))
-                           (buffer-list)))
+                               (and (bound-and-true-p tide-mode)
+                                    (equal (tide-project-name) project-name))))
+                             (buffer-list)))
     (with-current-buffer buffer
       (funcall fn))))
 
@@ -2356,7 +2355,7 @@ timeout."
 
 (defun tide--list-servers-verify-setup (button)
   "Invoke `tide-verify-setup' on a tsserver displayed in the list of server."
-  (tide-any-buffer (button-get button 'project-name) #'tide-verify-setup))
+  (tide-first-buffer (button-get button 'project-name) #'tide-verify-setup))
 
 ;; This is modeled after list-process--refresh but we do not call delete-process
 ;; on exited or signaled processe. That seems inappropriate for a function


### PR DESCRIPTION
I'm opening a PR so that this can be discussed before it is merged. Or so that it can be objected to, if there are objections.

The explosion of `tsserver` processes has been a bit of an issue for me. I can do `ps` at the command line but that's rather limited in usefulness. I can also use `M-x list-processes` but it shows things I don't care about and conversely does not readily provide information I care about when I'm inspecting `tsserver` processes. So I've worked on a `tide-list-servers` command which can help inspect the instance that tide has started. I've derived it from how `list-processes` does its job.

Things that can be done with it:

1. See the servers running.
2. Kill a server by hitting `d` in the `*Tide Server List*` buffer.
3. Verify the configuration of a server by going on its project name and hitting enter.

This is something I've just put up together, which I'm sure could be improved. Feedback welcomed.