### PR TITLE
sort the edits in descending order

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -1776,7 +1776,13 @@ code-analysis."
 (defun tide-apply-edits (edits)
   (save-excursion
     (-map (lambda (edit) (tide-apply-edit edit))
-          (nreverse edits))))
+          (-sort
+           (tide-compose-comparators
+            (lambda (a b)
+              (< (tide-plist-get b :start :line) (tide-plist-get a :start :line)))
+            (lambda (a b)
+              (< (tide-plist-get b :start :offset) (tide-plist-get a :start :offset))))
+           (nreverse edits)))))
 
 (defun tide-format-region (start end)
   (let ((response (tide-send-command-sync


### PR DESCRIPTION
fixes #288

> Applying the edit instructions in reverse to file will result in correctly reformatted text.

One of the comments in TypeScript repo says the edits should be applied
in reverse order. But, I am not sure all the plugins follows this? Doing
a manual sort does seem to fix the tslint issue. VS code applies the fixes
correctly, but I can't able to find the logic. Atom[1] also manually
sorts the edits.

1: https://github.com/TypeStrong/atom-typescript/blob/master/lib/main/pluginManager.ts#L349-L352