### PR TITLE
Formalize the range of Emacs versions supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ before_install:
   - cask
 
 env:
-  - EVM_EMACS=emacs-24.3-travis
   - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis

--- a/tide.el
+++ b/tide.el
@@ -202,6 +202,10 @@ this variable to non-nil value for Javascript buffers using `setq-local' macro."
   :group 'tide
   :safe #'booleanp)
 
+(defconst tide--minimal-emacs
+  "24.4"
+  "This is the oldest version of Emacs that tide supports.")
+
 (defmacro tide-def-permanent-buffer-local (name &optional init-value)
   "Declare NAME as buffer local variable."
   `(progn
@@ -1835,6 +1839,11 @@ code-analysis."
 (defun tide-setup ()
   "Setup `tide-mode' in current buffer."
   (interactive)
+
+  (when (version< emacs-version tide--minimal-emacs)
+    (display-warning 'tide (format "Tide requires Emacs >= %s, you are using %s."
+                                   tide--minimal-emacs emacs-version)
+                     :error))
 
   ;; Indirect buffers embedded in other major modes such as those in org-mode or
   ;; template languages have to be manually synchronized to tsserver. This might


### PR DESCRIPTION
Taking a page out of [magit](https://github.com/magit/magit), this PR adds code so that tide formally checks whether the Emacs it is running on is at least as new as the oldest version supported.

When the check fails, the user gets a warning. This is what magit does. I've not spent any time figuring out the pros and cons of showing a warning like magit does vs slamming the brakes with a hard failure.

This also removes 24.3 from testing, as 24.4 is the oldest version supported.