### PR TITLE
add command to show detailed error at point

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ and <kbd>p</kbd>. Press <kbd>enter</kbd> to open the file.
 project. Errors can be navigated using <kbd>n</kbd> and
 <kbd>p</kbd>. Press <kbd>enter</kbd> to open the file.
 
+<kbd>M-x tide-error-at-point</kbd> Show the details of the error at point.
+
 <kbd>M-x tide-rename-symbol</kbd> Rename all occurrences of the symbol
 at point.
 

--- a/tide.el
+++ b/tide.el
@@ -2036,6 +2036,7 @@ code-analysis."
         (mapconcat 'tide-format-related-information related "\n\n"))))))
 
 (defun tide-error-at-point ()
+  "Show the details of the error at point."
   (interactive)
   (-if-let (errors (flycheck-overlay-errors-at (point)))
       (tide-display-help-buffer "error"

--- a/tide.el
+++ b/tide.el
@@ -455,14 +455,23 @@ LINE is one based, OFFSET is one based and column is zero based"
       (forward-char (1- (plist-get span :offset)))
       (point))))
 
-(defun tide-doc-buffer (string)
-  (with-current-buffer (get-buffer-create "*tide-documentation*")
+(defun tide-display-help-buffer (feature body)
+  (let ((buffer (tide-make-help-buffer feature body)))
+    (display-buffer buffer t)
+    (if help-window-select
+        (progn
+          (pop-to-buffer buffer)
+          (message "Type \"q\" to restore previous buffer"))
+      (message (concat "Type \"q\" in the " feature " buffer to close it")))))
+
+(defun tide-make-help-buffer (feature body)
+  (with-current-buffer (get-buffer-create (concat "*tide-" feature "*"))
     (setq buffer-read-only t)
     (let ((inhibit-read-only t))
       (erase-buffer)
-      (when string
+      (when body
         (save-excursion
-          (tide-insert string))))
+          (tide-insert body))))
     (local-set-key (kbd "q") #'quit-window)
     (current-buffer)))
 
@@ -1017,11 +1026,10 @@ Noise can be anything like braces, reserved keywords, etc."
       (when (or (or (not (s-blank? documentation))
                     (not (s-blank? jsdoc)))
                 tide-always-show-documentation)
-        (tide-doc-buffer
-         (tide-join
-          (-concat (list display-string "\n\n")
-                   (if (not (s-blank? documentation)) (list documentation "\n\n") '())
-                   (list jsdoc))))))))
+        (tide-join
+         (-concat (list display-string "\n\n")
+                  (if (not (s-blank? documentation)) (list documentation "\n\n") '())
+                  (list jsdoc)))))))
 
 (defun tide-command:quickinfo-old (cb)
   (tide-send-command "quickinfo" `(:file ,(tide-buffer-file-name) :line ,(tide-line-number-at-pos) :offset ,(tide-current-offset)) cb))
@@ -1060,14 +1068,8 @@ Noise can be anything like braces, reserved keywords, etc."
   (interactive)
   (tide-command:quickinfo
    (tide-on-response-success-callback response
-     (-if-let (buffer (tide-construct-documentation (plist-get response :body)))
-         (progn
-           (display-buffer buffer t)
-           (if help-window-select
-               (progn
-                 (pop-to-buffer buffer)
-                 (message "Type \"q\" to restore previous buffer"))
-             (message "Type \"q\" in the documentation buffer to close it")))
+     (-if-let (body (tide-construct-documentation (plist-get response :body)))
+         (tide-display-help-buffer "documentation" body)
        (message "No documentation available.")))))
 
 ;;; Buffer Sync
@@ -1428,7 +1430,7 @@ This function is used for the basic completions sorting."
 (defun tide-completion-doc-buffer (name)
   (-when-let* ((response (tide-completion-entry-details name))
                (detail (car (plist-get response :body))))
-    (tide-construct-documentation detail)))
+    (tide-make-help-buffer "documentation" (tide-construct-documentation detail))))
 
 (defun tide-post-completion (name)
   (let ((completion (get-text-property 0 'completion name))
@@ -1969,8 +1971,12 @@ code-analysis."
      (let* ((start (plist-get diagnostic :start))
             (line (plist-get start :line))
             (column (tide-column line (plist-get start :offset)))
-            (level (if (string= (plist-get diagnostic :category) "suggestion") 'info 'error)))
-       (flycheck-error-new-at line column level (plist-get diagnostic :text)
+            (level (if (string= (plist-get diagnostic :category) "suggestion") 'info 'error))
+            (text (plist-get diagnostic :text)))
+       (when (plist-get diagnostic :relatedInformation)
+         (setq text (concat text (propertize " ⮐" 'face 'font-lock-warning-face))))
+       (put-text-property 0 1 'diagnostic diagnostic text)
+       (flycheck-error-new-at line column level text
                               :checker checker
                               :id (plist-get diagnostic :code))))
    (let ((diagnostic (car (tide-plist-get response :body))))
@@ -1991,6 +1997,50 @@ code-analysis."
      (if (tide-response-success-p response)
          (tide-flycheck-send-response callback checker response)
        (funcall callback 'errored (plist-get response :message))))))
+
+(defun tide-make-clickable-filespan (filespan)
+  (propertize
+   (concat
+    (file-name-nondirectory (plist-get filespan :file))
+    ":"
+    (number-to-string (tide-plist-get filespan :start :line)))
+   'face 'link
+   'help-echo "mouse-2: go to this location"
+   'keymap (let ((map (make-sparse-keymap)))
+             (define-key map [mouse-2] 'tide-goto-error)
+             (define-key map [mouse-1] 'tide-goto-error)
+             (define-key map (kbd "C-m") 'tide-goto-error)
+             (define-key map [follow-link] 'mouse-face)
+             map)
+   'tide-error filespan))
+
+(defun tide-format-related-information (related)
+  (concat
+   (tide-make-clickable-filespan (plist-get related :span))
+   " "
+   (plist-get related :message)
+   " [" (number-to-string (plist-get related :code)) "]"))
+
+(defun tide-explain-error (err)
+  (let* ((diagnostic (get-text-property 0 'diagnostic (flycheck-error-message err)))
+         (related (plist-get diagnostic :relatedInformation)))
+    (concat
+     (propertize "Code: " 'face 'bold) (number-to-string (plist-get diagnostic :code)) " "
+     (propertize "Category: " 'face 'bold) (plist-get diagnostic :category)
+     "\n\n"
+     (plist-get diagnostic :text)
+     "\n\n"
+     (when related
+       (concat
+        (propertize "Related Information: \n\n" 'face 'bold)
+        (mapconcat 'tide-format-related-information related "\n\n"))))))
+
+(defun tide-error-at-point ()
+  (interactive)
+  (-if-let (errors (flycheck-overlay-errors-at (point)))
+      (tide-display-help-buffer "error"
+        (mapconcat #'tide-explain-error errors "\n\n--------\n\n"))
+    (message "No errors available.")))
 
 (defun tide-flycheck-verify (_checker)
   (list


### PR DESCRIPTION
see #275 for context

I initially thought of adding the extra information after the current normal message as @josteink suggested.

Some drawbacks of that approach are
1) we won't be able to navigate to the location 
2) minibuffer height is usually fixed, anything more than 4 lines is usually a problem

![screen shot 2019-02-04 at 3 52 32 pm](https://user-images.githubusercontent.com/149238/52202598-f90a8d80-2894-11e9-9b6e-c2949b9ec0b6.png)

An arrow is shown in the end if there are any related information available. User can then run `M-x tide-error-at-point`, which will bring up a buffer. Similar to `tide-documentation-at-point`. The link to the file position is clickable.

![screen shot 2019-02-04 at 3 52 48 pm](https://user-images.githubusercontent.com/149238/52202599-fc057e00-2894-11e9-802c-cbc5d5327ea9.png)

Flycheck has `flycheck-explain-error-at-point` command, I attempted to integrate with it, but unfortunately it doesn't allow clickable link. It uses `princ` internally which ignores all the text properties.
