### PR TITLE
allow not starting tsserver immediately when starting tide

### DIFF
--- a/test/trivial2.ts
+++ b/test/trivial2.ts
@@ -1,0 +1,1 @@
+const bar = 1;

--- a/tide.el
+++ b/tide.el
@@ -2087,6 +2087,8 @@ current buffer."
   (set (make-local-variable 'imenu-create-index-function)
        'tide-imenu-index)
 
+  (tide-mode 1)
+
   (if (tide-current-server)
       ;;
       ;; We want to issue tide-configure-buffer here if the server exists.  We
@@ -2099,9 +2101,7 @@ current buffer."
       ;;
       (tide-configure-buffer)
     (when (eq tide-tsserver-start-method 'immediate)
-      (tide-start-server)))
-
-  (tide-mode 1))
+      (tide-start-server))))
 
 ;;;###autoload
 (define-minor-mode tide-mode

--- a/tide.el
+++ b/tide.el
@@ -2087,8 +2087,20 @@ current buffer."
   (set (make-local-variable 'imenu-create-index-function)
        'tide-imenu-index)
 
-  (when (eq tide-tsserver-start-method 'immediate)
-    (tide-start-server-if-nonexistent))
+  (if (tide-current-server)
+      ;;
+      ;; We want to issue tide-configure-buffer here if the server exists.  We
+      ;; cannot rely on hack-local-variable-hook in tide-mode because the hook
+      ;; may not run at all, or run too late.
+      ;;
+      ;; It may happen for some use-case scenarios that tide-configure-buffer
+      ;; runs more than once with the same data for the same buffer, but that's
+      ;; not a big deal.
+      ;;
+      (tide-configure-buffer)
+    (when (eq tide-tsserver-start-method 'immediate)
+      (tide-start-server)))
+
   (tide-mode 1))
 
 ;;;###autoload

--- a/tide.el
+++ b/tide.el
@@ -799,7 +799,8 @@ Currently, two kinds of cleanups are done:
       (sit-for 5)
       (message nil))))
 
-(defun tide-start-server-if-required ()
+(defun tide-start-server-if-nonexistent ()
+  "Start a tsserver instance if there is not one already running."
   (unless (tide-current-server)
     (tide-start-server)))
 
@@ -2052,7 +2053,7 @@ code-analysis."
   (unless (stringp buffer-file-name)
     (setq tide-require-manual-setup t))
 
-  (tide-start-server-if-required)
+  (tide-start-server-if-nonexistent)
   (tide-mode 1)
   (set (make-local-variable 'eldoc-documentation-function)
        'tide-eldoc-function)

--- a/tide.el
+++ b/tide.el
@@ -2626,11 +2626,16 @@ identifier at point, if necessary."
 
 ;;; Utility commands
 
+(defun tide-kill-server ()
+  "Kill the server in the current buffer."
+  (interactive)
+  (-when-let (server (tide-current-server))
+    (delete-process server)))
+
 (defun tide-restart-server ()
   "Restarts tsserver."
   (interactive)
-  (-when-let (server (tide-current-server))
-    (delete-process server))
+  (tide-kill-server)
   (tide-start-server))
 
 (defvar-local tide--server-list-mode-last-column nil)


### PR DESCRIPTION
This is the companion WIP to issue #294 

I've been using this for a few weeks now without running into actual issues (commit dates are deceptive: I used it before the code was committed) so I figure I should put it up for public view.

Going into a buffer that does not have `tsserver` started causes some things to not work but *that's expected*. When I finally start a `tsserver` manually it works just as well as if the server had been started automatically.