### PR TITLE
use tsc --showConfig to read config

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,13 @@ paths are resolved against the project root directory.
 Note that this option only works with TypeScript version 2.0 and
 above.
 
+##### tide-tscompiler-executable `nil`
+
+Name of tsc executable.
+
+This may either be an absolute path or a relative path. Relative
+paths are resolved against the project root directory.
+
 ##### tide-node-executable `"node"`
 
 Name or path of the node executable binary file.

--- a/test/base.json
+++ b/test/base.json
@@ -1,7 +1,0 @@
-{
-  "compileOnSave": true,
-  "compilerOptions": {
-    "target": "ES6",
-    "sourceMap": true
-  }
-}

--- a/test/loop.json
+++ b/test/loop.json
@@ -1,6 +1,0 @@
-{
-  "compilerOptions": {
-    "target": "ES7"
-  },
-  "extends": "./loop.json"
-}

--- a/test/tsconfig-no-extension.json
+++ b/test/tsconfig-no-extension.json
@@ -1,6 +1,0 @@
-{
-  "compilerOptions": {
-    "target": "ES7"
-  },
-  "extends": "./base"
-}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
     "target": "ES7"
-  },
-  "extends": "./base.json"
+  }
 }

--- a/tide-tests.el
+++ b/tide-tests.el
@@ -111,20 +111,6 @@
   (should (tide-plist-equal '(:a 1 :b (:nest 1 :nest2 2)) '(:a 1 :b (:nest2 2 :nest 1))))
   (should-not (tide-plist-equal '(:a 1 :b (:nest 1)) '(:a 1 :b (:nest 2)))))
 
-(ert-deftest load-tsconfig ()
-  (should (tide-plist-equal '(:compilerOptions (:target "ES7" :sourceMap t) :extends "./base.json" :compileOnSave t)
-                 (tide-load-tsconfig "test/tsconfig.json" '())))
-
-  (should (tide-plist-equal '(:compilerOptions (:target "ES7" :sourceMap t) :extends "./base" :compileOnSave t)
-                            (tide-load-tsconfig "test/tsconfig-no-extension.json" '())))
-
-  (should (tide-plist-equal '(:compileOnSave t :compilerOptions (:target "ES6" :sourceMap t))
-                 (tide-load-tsconfig "test/base.json" '())))
-
-  (should-error (tide-load-tsconfig "test/loop.json" '()))
-
-  (should-error (tide-load-tsconfig "test/notfound.json" '())))
-
 ;; Adapted from jdee-mode's test suite.
 (defmacro mode-with-temp-buffer (content &rest body)
   "Fill a temporary buffer with `CONTENT', turn on `tide-mode' and eval `BODY' in it."


### PR DESCRIPTION
Note: This breaks backward compatibility as --showConfig is only introduced in 3.2. But given that the config is only used by a small feature and maintaining backward compatibility will make the code too complicated, I am leaning towards only supporting 3.2 for this feature 

fixes #310 @zhenwenc please help with testing