### PR TITLE
Highlight fewer references in large buffers

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -2354,8 +2354,17 @@ highlights from previously highlighted identifier."
   (-when-let* ((item (-first (lambda (item)
                                (equal (tide-buffer-file-name) (plist-get item :file)))
                              (plist-get response :body)))
-               (references (plist-get item :highlightSpans)))
-    (-each references
+               (references (plist-get item :highlightSpans))
+               (nearby-references
+                (if (and
+                     (> (length references) 20)
+                     (> (plist-get (plist-get (-last-item references) :start) :line) 10000))
+                    (let ((start-line (- (line-number-at-pos) 100)))
+                      (-take 20 (-drop-while
+                                 (lambda (r) (> start-line (plist-get (plist-get r :start) :line)))
+                                 references)))
+                  references)))
+    (-each nearby-references
       (lambda (reference)
         (let* ((kind (plist-get reference :kind))
                (id-start (plist-get reference :start))


### PR DESCRIPTION
tide-location-to-point is slow (linear?) in large buffers. When you highlight something with lots of references like `boolean` or some other common data type, tide will freeze while highlighting references.

This change highlights only 20 nearby references in large buffers, which are defined as >10,000 lines.

The right fix is probably to make `tide-location-to-point` fast, but I don't know enough about emacs to do that.