### PR TITLE
Improve the speed of tide--hl-highlight.

### DIFF
--- a/test/highlight.ts
+++ b/test/highlight.ts
@@ -1,0 +1,9 @@
+type Fnord = number;
+
+function foo(a: Fnord, b: Fnord): Fnord {
+    return a + b;
+}
+
+const moo: Fnord = 1;
+
+foo();

--- a/tide-tests.el
+++ b/tide-tests.el
@@ -280,6 +280,23 @@ a test failure."
     (wait-for
      (should (member "*tide-project-info*" (mapcar (function buffer-name) (buffer-list)))))))
 
+(ert-deftest test-tide-hl-identifier ()
+  "Test that `tide-hl-identifier' highlights the identifiers properly."
+  (let* ((buffer (find-file "test/highlight.ts")))
+    (tide-setup)
+    (re-search-forward "Fnord")
+    (tide-hl-identifier)
+    ;; `tide-hl-identifier' is asynchronous so we need to wait until
+    ;; it is done.
+    (wait-for
+     (should (= (length (overlays-in (point-min) (point-max))) 5)))
+    (dolist (overlay (overlays-in (point-min) (point-max)))
+      (should (string= (buffer-substring (overlay-start overlay)
+                                         (overlay-end overlay))
+                       "Fnord")))
+    (delete-process (tide-current-server))
+    (kill-buffer buffer)))
+
 (provide 'tide-tests)
 
 ;;; tide-tests.el ends here


### PR DESCRIPTION
I'm proposing this instead of #324 

The problem with `tide--hl-highlight` being slow is that `tide-location-to-point` is extremely slow because with every invocation it goes back to `point-min` and moves forward to find the point to return. I've briefly investigated whether it was possible to *only* replace the guts of `tide-location-to-point` with something speedier but I've not found a way to do this.

What I ended up with is a specialized loop that remembers from iteration to iteration which line it is at in the buffer so it does not keep jumping around the buffer. With this modification, when I use `benchmark-elapse` (from `benchmark.el`) to time `tide--hl-highlight` I get a run time of 0.0034 down from about 1.3 prior to the modification. This is using @sandersn's test case: the `checker.ts` file in the source code of TypeScript and highlighting the `Node` identifier. 

I'm putting this up for discussion. There are two things I'm unsure about that may impact this code:

1. Can a column number or a line number reported by `tsserver` ever be 0. If not, then the test `(when (not (and (= start-col 0) (= start-line 0)))` is pointless. I'm inclined to think that `tsserver` won't ever report a line number of 0 or a column number of 0... but maybe there's some case I'm not thinking about.

2. Is it possible for a TypeScript identifier to span more than one line? I'm pretty sure the answer is "no", and the code I currently have that checks whether the end is on a different line from the start could be removed. Then again, maybe there some weird Unicode case I'm not aware of.

----

While writing the above and adding the timing results, I discovered a baffling case:

1. Open `checker.ts`, turn off `tide-hl-identifier-mode`, or keep it off it is not on. We want to control when the highlighting happens.
2. Go to the last instance of `Node` in the buffer and issue `M-x tide-hl-identifier`. This runs fast.
3. Go to the first instance of `Node` in the buffer and issue `M-x tide-hl-identifier`. There's a loong delay before control is returned to the user.

However, I think the problem is Emacs and large buffers, not `tide`, because I can still reproduce the same strange delay if I do this:

1. Copy `checker.ts` to `/tmp/q.txt` and open the new file. The goal is to have Emacs open the file without using `tide`. Emacs opens it in `text` mode with my setup.
2. Go to the end of the file.
3. Go to the start of the file.
4. Issue `M-C-x (goto-char 1)`. The same strange delay happens.