### PR TITLE
Fix highlighting when the file contains tabs.

### DIFF
--- a/test/highlight-tabs.ts
+++ b/test/highlight-tabs.ts
@@ -1,11 +1,14 @@
 type Fnord = number;
 
 function foo(a: Fnord, b: Fnord): Fnord {
-    return a + b;
+	while (a + b) {
+		a = a - b;
+	}
+	return a + b;
 }
 
 const moo: Fnord = 1;
 
 foo();
 
-export {}
+export {};

--- a/tide-tests.el
+++ b/tide-tests.el
@@ -279,8 +279,9 @@ a test failure."
     (wait-for
      (should (member "*tide-project-info*" (mapcar (function buffer-name) (buffer-list)))))))
 
-(ert-deftest test-tide-hl-identifier ()
-  "Test that `tide-hl-identifier' highlights the identifiers properly."
+(ert-deftest test-tide-hl-identifier/spaces ()
+  "Test that `tide-hl-identifier' highlights the identifiers properly in a
+file that uses spaces for indentation."
   (let* ((buffer (find-file "test/highlight.ts")))
     (tide-setup)
     (re-search-forward "Fnord")
@@ -293,6 +294,25 @@ a test failure."
       (should (string= (buffer-substring (overlay-start overlay)
                                          (overlay-end overlay))
                        "Fnord")))
+    (delete-process (tide-current-server))
+    (kill-buffer buffer)))
+
+(ert-deftest test-tide-hl-identifier/tabs ()
+  "Test that `tide-hl-identifier' highlights the identifiers properly in a
+file that uses tabs for indentation."
+  (let* ((buffer (find-file "test/highlight-tabs.ts")))
+    (tide-setup)
+    (goto-char (point-max))
+    (re-search-backward "a: ")
+    (tide-hl-identifier)
+    ;; `tide-hl-identifier' is asynchronous so we need to wait until
+    ;; it is done.
+    (wait-for
+     (should (= (length (overlays-in (point-min) (point-max))) 5)))
+    (dolist (overlay (overlays-in (point-min) (point-max)))
+      (should (string= (buffer-substring (overlay-start overlay)
+                                         (overlay-end overlay))
+                       "a")))
     (delete-process (tide-current-server))
     (kill-buffer buffer)))
 

--- a/tide.el
+++ b/tide.el
@@ -2376,12 +2376,13 @@ highlights from previously highlighted identifier."
                        (start-line (plist-get start :line))
                        (overlay (make-overlay
                            (progn (forward-line (- start-line current-line))
-                                  (move-to-column (1- (plist-get start :offset)))
+                                  (forward-char (1- (plist-get start :offset)))
                                   (point))
                            (progn (unless (= start-line (plist-get end :line))
                                     ;; Identifiers shouldn't span lines.
                                     (error "identifier unexpectedly spans lines"))
-                                  (move-to-column (1- (plist-get end :offset)))
+                                  (forward-char (- (plist-get end :offset)
+                                                   (plist-get start :offset)))
                                   (point)))))
                   (setq current-line start-line)
                   (overlay-put overlay 'tide-overlay 'sameid)


### PR DESCRIPTION
Fixes #337

As the documentation of `move-to-column` states, it calculates the width of each character. A tab counts 8 character wide even though it is only one character in the source code, etc. Hilarity ensues. Use `forward-char` instead.

@zanemayo please try it out on substantial files.
