### PR TITLE
Project cleanup when buffers are killed

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -739,6 +739,9 @@ in the npm global installation.  If nothing is found use the bundled version."
   (tide-each-buffer project-name
                     (lambda ()
                       (tide-cleanup-buffer-callbacks)))
+  (tide-cleanup-project-data project-name))
+
+(defun tide-cleanup-project-data (project-name)
   (remhash project-name tide-servers)
   (remhash project-name tide-tsserver-unsupported-commands)
   (remhash project-name tide-project-configs))
@@ -764,7 +767,7 @@ In particular, kill their tsserver processes."
       (message "Cleaning up %d projects..." (length to-kill))
       (dolist (proj to-kill)
         (delete-process (process-buffer (gethash proj tide-servers)))
-        (tide-cleanup-project proj))
+        (tide-cleanup-project-data proj))
       (sit-for 5)
       (message nil))))
 

--- a/tide.el
+++ b/tide.el
@@ -762,7 +762,9 @@ In particular, kill their tsserver processes."
         (cl-pushnew proj live-projects)))
     (-when-let (to-kill (-difference (hash-table-keys tide-servers) live-projects))
       (message "Cleaning up %d projects..." (length to-kill))
-      (dolist (proj to-kill) (tide-cleanup-project proj))
+      (dolist (proj to-kill)
+        (delete-process (process-buffer (gethash proj tide-servers)))
+        (tide-cleanup-project proj))
       (sit-for 5)
       (message nil))))
 


### PR DESCRIPTION
There is a general tendency to accumulate many servers since they're
never removed (actually, more than just the servers -- the whole project
resources are kept, but the server is the main problem wrt resources).
This is also mentioned in #256.

So I implemented a function that scans all buffers and cleanup all
projects that have no live buffers.  It looks to me like a good idea to
do this, since you can just kill old buffers to reduce resource
usage.  (And killing old buffers is more obvious than explicitly
openning the server list to kill old ones, especially since there's no
way to tell if a server is used by some buffer or not.)

(I added this function onto `kill-buffer-hook`, but if that's too
extreme, then a more mild option is to not do that and just let people
add it themselves.)