### PR TITLE
Better `tide-file` face definition

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -146,7 +146,7 @@ errors and tide-project-errors buffer."
   :group 'tide)
 
 (defface tide-file
-  '((t (:inherit dired-header)))
+  '((t (:inherit font-lock-type-face)))
   "Face for file names in references output."
   :group 'tide)
 


### PR DESCRIPTION
Make `tide-file` inherit directly from `font-lock-type-face` instead of
`dired-header`, since that doesn't exist until `dired` is used (so
opening the references before dired gets no highlights).