### PR TITLE
Find tsserver and tsc via exec-path

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -666,6 +666,7 @@ npm local package directory, in the project root as defined by projectile, and
 in the npm global installation."
   (or
    (and tide-tscompiler-executable (expand-file-name tide-tscompiler-executable))
+   (executable-find "tsc")
    (tide-tscompiler-locater-npmlocal-projectile-npmglobal)))
 
 (defconst tide--tsserver "tsserver.js"
@@ -692,6 +693,7 @@ npm local package directory, in the project root as defined by projectile, and
 in the npm global installation.  If nothing is found use the bundled version."
   (or
    (and tide-tsserver-executable (expand-file-name tide-tsserver-executable))
+   (executable-find "tsserver")
    (funcall tide-tsserver-locator-function)
    (expand-file-name tide--tsserver tide-tsserver-directory)))
 


### PR DESCRIPTION
For people using nvm and https://github.com/rejeep/nvm.el, this will find the typescript executables installed globally for the particular version of node that is currently activated, if any. For example, when I've used nvm.el to activate v10.16.3, then it will find `/Users/william/.nvm/versions/node/v10.16.3/bin/tsserver`, which none of the existing methods would have found.