### PR TITLE
Add optional tide-jump-to-fallback

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -211,6 +211,11 @@ source blocks) in."
   :type 'boolean
   :group 'tide)
 
+(defcustom tide-jump-to-fallback #'tide-jump-to-fallback-not-given
+  "The fallback jump function to use when implementations aren't available."
+  :type 'function
+  :group 'tide)
+
 (defcustom tide-filter-out-warning-completions nil
   "Completions whose `:kind' property is \"warning\" will be filtered out if set to non-nil.
 This option is useful for Javascript code completion, because tsserver often returns a lot of irrelevant
@@ -905,6 +910,9 @@ implementations.  When invoked with a prefix arg, jump to the type definition."
 
 ;;; Jump to implementation
 
+(defun tide-jump-to-fallback-not-given ()
+  (message "No implementations available."))
+
 (defun tide-command:implementation ()
   (tide-send-command-sync
    "implementation"
@@ -934,7 +942,7 @@ implementations.  When invoked with a prefix arg, jump to the type definition."
     (tide-on-response-success response
       (let ((impls (plist-get response :body)))
         (cl-case (length impls)
-          ((0) (message "No implementations available."))
+          ((0) (funcall tide-jump-to-fallback))
           ((1) (tide-jump-to-filespan (car impls)))
           (t (tide-jump-to-filespan
               (tide-select-item-from-list "Select implementation: " impls


### PR DESCRIPTION
Occasionally tide won't be able to find a definition. In cases like this it'd be nice to fallback to another jump method (e.g. [dumb-jump](https://github.com/jacktasia/dumb-jump)).

Here's an approach that I'm finding useful:
```elisp
(use-package tide
  :ensure t
  :after (typescript-mode company)
  :config
  (setq tide-jump-to-fallback 'dumb-jump-go)
  :hook ((typescript-mode . tide-setup)
         (typescript-mode . tide-hl-identifier-mode)
         (before-save . tide-format-before-save)))
```