### PR TITLE
Fix formatting with different tabSize/indentSize

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -784,7 +784,7 @@ in the npm global installation.  If nothing is found use the bundled version."
 
 (defun tide-file-format-options ()
   (tide-combine-plists
-   `(:tabSize ,tab-width :indentSize ,(tide-current-indentsize))
+   `(:TabSize ,tab-width :IndentSize ,(tide-current-indentsize))
    tide-format-options
    (tide-tsfmt-options)))
 


### PR DESCRIPTION
Previously Tide would also format using 4 spaces. (It would ignore `tab-width`)
Fix #354