### PR TITLE
Fix `upcase(nil)` error

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -876,7 +876,7 @@ Currently, two kinds of cleanups are done:
                            :scriptKindName ,tide-default-mode
                            :fileContent ,(buffer-string))
                        (append `(:file ,(tide-buffer-file-name))
-                               (let ((extension (upcase (file-name-extension (tide-buffer-file-name)))))
+                               (let ((extension (upcase (or (file-name-extension (tide-buffer-file-name)) ""))))
                                  (when (member extension '("TS" "JS" "TSX" "JSX"))
                                    `(:scriptKindName ,extension)))))))
 


### PR DESCRIPTION
An error occurs if the file name has no extension.

```
Debugger entered--Lisp error: (wrong-type-argument char-or-string-p nil)
  upcase(nil)
  (let ((extension (upcase (file-name-extension (tide-buffer-file-name))))) (if (member extension (quote ("TS" "JS" "TSX" "JSX"))) (progn (list (quote :scriptKindName) extension))))
  (append (list (quote :file) (tide-buffer-file-name)) (let ((extension (upcase (file-name-extension (tide-buffer-file-name))))) (if (member extension (quote ("TS" "JS" "TSX" "JSX"))) (progn (list (quote :scriptKindName) extension)))))
  (if tide-require-manual-setup (list (quote :file) (tide-buffer-file-name) (quote :scriptKindName) tide-default-mode (quote :fileContent) (buffer-string)) (append (list (quote :file) (tide-buffer-file-name)) (let ((extension (upcase (file-name-extension (tide-buffer-file-name))))) (if (member extension (quote ("TS" "JS" "TSX" "JSX"))) (progn (list (quote :scriptKindName) extension))))))
  (tide-send-command "open" (if tide-require-manual-setup (list (quote :file) (tide-buffer-file-name) (quote :scriptKindName) tide-default-mode (quote :fileContent) (buffer-string)) (append (list (quote :file) (tide-buffer-file-name)) (let ((extension (upcase (file-name-extension ...)))) (if (member extension (quote ("TS" "JS" "TSX" "JSX"))) (progn (list (quote :scriptKindName) extension)))))))
  tide-command:openfile()
  tide-configure-buffer()
  #f(compiled-function (buffer) #<bytecode 0x73800f01>)(#<buffer CLI-WRITTEN-IN-TYPESCRIPT>)
  -each((#<buffer CLI-WRITTEN-IN-TYPESCRIPT> ...) #f(compiled-function (buffer) #<bytecode 0x73800f01>))
  tide-each-buffer("..." tide-configure-buffer)
  tide-start-server()
  tide-restart-server()
  funcall-interactively(tide-restart-server)
  call-interactively(tide-restart-server record nil)
  command-execute(tide-restart-server record)
  execute-extended-command(nil "tide-restart-server" nil)
  funcall-interactively(execute-extended-command nil "tide-restart-server" nil)
  call-interactively(execute-extended-command nil nil)
  command-execute(execute-extended-command)
```