### PR TITLE
Use native JSON parsing when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,3 +345,6 @@ this variable to non-nil value for Javascript buffers using `setq-local` macro.
 
 How long to wait after user input before highlighting the current identifier.
 
+##### tide-native-json-parsing `nil`
+
+Use the native JSON functions for encoding and decoding.

--- a/test/test.json
+++ b/test/test.json
@@ -1,0 +1,40 @@
+{
+    "files": [
+        "./lib/cli.ts",
+        "./lib/index.ts",
+        "./test/indexSpec.ts",
+        "./typings/bundle.d.ts",
+        "./typings/empower/empower.d.ts",
+        "./typings/gulp/gulp.d.ts",
+        "./typings/mocha/mocha.d.ts",
+        "./typings/node/node.d.ts",
+        "./typings/orchestrator/orchestrator.d.ts",
+        "./typings/power-assert-formatter/power-assert-formatter.d.ts",
+        "./typings/power-assert/power-assert.d.ts",
+        "./typings/q/Q.d.ts",
+        "./node_modules/typescript/lib/lib.es6.d.ts"
+    ],
+    "exclude": [],
+    "filesGlob": [
+        "./**/*.ts",
+        "./**/*.tsx",
+        "!./**/*.d.ts",
+        "!./gulpfile.ts",
+        "./typings/**/*.d.ts",
+        "!./node_modules/**/*.ts",
+        "./node_modules/typescript/lib/lib.es6.d.ts"
+    ],
+    "compilerOptions": {
+        "noEmitOnError": true,
+        "newLine": "LF",
+        "listFiles": true,
+        "sourceMap": true,
+        "rootDir": ".",
+        "experimentalDecorators": true,
+        "removeComments": true,
+        "noImplicitAny": true,
+        "declaration": true,
+        "module": "commonjs",
+        "target": "es5"
+    }
+}

--- a/tide-tests.el
+++ b/tide-tests.el
@@ -432,58 +432,61 @@ file that uses tabs for indentation."
                        "a")))
     (delete-process (tide-current-server))
     (kill-buffer buffer)))
+(when (>= emacs-major-version 27)
+  (ert-deftest test-tide-safe-json-read-file ()
+    "Test that `tide-safe-json-read-file' produces the same output for both json.el and the native json parser"
+    (let ((native-output
+           (let ((tide-native-json-parsing t))
+             (tide-safe-json-read-file "test/test.json")))
+          (elisp-output
+           (let ((tide-native-json-parsing nil))
+             (tide-safe-json-read-file "test/test.json"))))
+      (should (equal native-output elisp-output)))))
 
-(ert-deftest test-tide-safe-json-read-file ()
-  "Test that `tide-safe-json-read-file' produces the same output for both json.el and the native json parser"
-  (let ((native-output
-         (let ((tide-native-json-parsing t))
-           (tide-safe-json-read-file "test/test.json")))
-        (elisp-output
-         (let ((tide-native-json-parsing nil))
-           (tide-safe-json-read-file "test/test.json"))))
-    (should (equal native-output elisp-output))))
-
-(ert-deftest test-tide-safe-json-read-string ()
-  "Test that `tide-safe-json-read-string' produces the same output for both native and elisp JSON libraries"
-  (let* ((test-json
-          (with-temp-buffer
-            (insert-file-contents "test/test.json")
-            (buffer-string)))
-         (native-output
-          (let ((tide-native-json-parsing t))
-            (tide-safe-json-read-string test-json)))
-         (elisp-output
-          (let ((tide-native-json-parsing nil))
-            (tide-safe-json-read-string test-json))))
-    (should (equal native-output elisp-output))))
-
-(ert-deftest test-tide-json-read-object ()
-  "Test that `tide-json-read-object' produces the same output for both native and elisp JSON libraries"
-  (let* ((native-output
-          (with-temp-buffer
-            (insert-file-contents "test/test.json")
+(when (>= emacs-major-version 27)
+  (ert-deftest test-tide-safe-json-read-string ()
+    "Test that `tide-safe-json-read-string' produces the same output for both native and elisp JSON libraries"
+    (let* ((test-json
+            (with-temp-buffer
+              (insert-file-contents "test/test.json")
+              (buffer-string)))
+           (native-output
             (let ((tide-native-json-parsing t))
-              (tide-json-read-object))))
-         (elisp-output
-          (with-temp-buffer 
-            (insert-file-contents "test/test.json")
+              (tide-safe-json-read-string test-json)))
+           (elisp-output
             (let ((tide-native-json-parsing nil))
-              (tide-json-read-object)))))
-    (should (equal native-output elisp-output))))
+              (tide-safe-json-read-string test-json))))
+      (should (equal native-output elisp-output)))))
 
-(ert-deftest test-tide-json-encode ()
-  "Test that `tide-json-read-object' produces the same JSON string for both native and elisp libraries"
-  (let* ((json-obj `(:number 123
-                     :string "string"
-                     :true t
-                     :false ,json-false
-                     :array [(:number 123 :string "string" :true t :false ,json-false)]))
-         (native-string (let ((tide-native-json-parsing t))
-                          (tide-json-encode json-obj)))
-         (elisp-string (let ((tide-native-json-parsing nil))
-                         (tide-json-encode json-obj))))
-    (should (equal native-string elisp-string))))
+(when (>= emacs-major-version 27)
+  (ert-deftest test-tide-json-read-object ()
+    "Test that `tide-json-read-object' produces the same output for both native and elisp JSON libraries"
+    (let* ((native-output
+            (with-temp-buffer
+              (insert-file-contents "test/test.json")
+              (let ((tide-native-json-parsing t))
+                (tide-json-read-object))))
+           (elisp-output
+            (with-temp-buffer
+              (insert-file-contents "test/test.json")
+              (let ((tide-native-json-parsing nil))
+                (tide-json-read-object)))))
+      (should (equal native-output elisp-output)))))
 
-(provide 'tide-tests)
+(when (>= emacs-major-version 27)
+  (ert-deftest test-tide-json-encode ()
+    "Test that `tide-json-read-object' produces the same JSON string for both native and elisp libraries"
+    (let* ((json-obj `(:number 123
+                               :string "string"
+                               :true t
+                               :false ,json-false
+                               :array [(:number 123 :string "string" :true t :false ,json-false)]))
+           (native-string (let ((tide-native-json-parsing t))
+                            (tide-json-encode json-obj)))
+           (elisp-string (let ((tide-native-json-parsing nil))
+                           (tide-json-encode json-obj))))
+      (should (equal native-string elisp-string))))
+
+  (provide 'tide-tests))
 
 ;;; tide-tests.el ends here

--- a/tide-tests.el
+++ b/tide-tests.el
@@ -433,6 +433,57 @@ file that uses tabs for indentation."
     (delete-process (tide-current-server))
     (kill-buffer buffer)))
 
+(ert-deftest test-tide-safe-json-read-file ()
+  "Test that `tide-safe-json-read-file' produces the same output for both json.el and the native json parser"
+  (let ((native-output
+         (let ((tide-native-json-parsing t))
+           (tide-safe-json-read-file "test/test.json")))
+        (elisp-output
+         (let ((tide-native-json-parsing nil))
+           (tide-safe-json-read-file "test/test.json"))))
+    (should (equal native-output elisp-output))))
+
+(ert-deftest test-tide-safe-json-read-string ()
+  "Test that `tide-safe-json-read-string' produces the same output for both native and elisp JSON libraries"
+  (let* ((test-json
+          (with-temp-buffer
+            (insert-file-contents "test/test.json")
+            (buffer-string)))
+         (native-output
+          (let ((tide-native-json-parsing t))
+            (tide-safe-json-read-string test-json)))
+         (elisp-output
+          (let ((tide-native-json-parsing nil))
+            (tide-safe-json-read-string test-json))))
+    (should (equal native-output elisp-output))))
+
+(ert-deftest test-tide-json-read-object ()
+  "Test that `tide-json-read-object' produces the same output for both native and elisp JSON libraries"
+  (let* ((native-output
+          (with-temp-buffer
+            (insert-file-contents "test/test.json")
+            (let ((tide-native-json-parsing t))
+              (tide-json-read-object))))
+         (elisp-output
+          (with-temp-buffer 
+            (insert-file-contents "test/test.json")
+            (let ((tide-native-json-parsing nil))
+              (tide-json-read-object)))))
+    (should (equal native-output elisp-output))))
+
+(ert-deftest test-tide-json-encode ()
+  "Test that `tide-json-read-object' produces the same JSON string for both native and elisp libraries"
+  (let* ((json-obj `(:number 123
+                     :string "string"
+                     :true t
+                     :false ,json-false
+                     :array [(:number 123 :string "string" :true t :false ,json-false)]))
+         (native-string (let ((tide-native-json-parsing t))
+                          (tide-json-encode json-obj)))
+         (elisp-string (let ((tide-native-json-parsing nil))
+                         (tide-json-encode json-obj))))
+    (should (equal native-string elisp-string))))
+
 (provide 'tide-tests)
 
 ;;; tide-tests.el ends here

--- a/tide.el
+++ b/tide.el
@@ -1290,7 +1290,7 @@ Noise can be anything like braces, reserved keywords, etc."
    `(:file ,(tide-buffer-file-name)
      :startLine ,(tide-line-number-at-pos) :startOffset ,(tide-current-offset)
      :endLine ,(tide-line-number-at-pos) :endOffset ,(+ 1 (tide-current-offset))
-     :errorCodes ,(tide-get-flycheck-errors-ids-at-point))))
+     :errorCodes ,(vconcat (tide-get-flycheck-errors-ids-at-point)))))
 
 (defun tide-command:getCombinedCodeFix (fixId)
   (tide-send-command-sync "getCombinedCodeFix"

--- a/tide.el
+++ b/tide.el
@@ -242,7 +242,8 @@ this variable to non-nil value for Javascript buffers using `setq-local' macro."
 (defcustom tide-native-json-parsing (and (>= emacs-major-version 27)
                                          (functionp 'json-serialize)
                                          (functionp 'json-parse-buffer)
-                                         (functionp 'json-parse-string))
+                                         (functionp 'json-parse-string)
+                                         nil)
   "Use native JSON parsing (only emacs >= 27)."
   :type 'boolean
   :group 'tide)

--- a/tide.el
+++ b/tide.el
@@ -239,7 +239,7 @@ this variable to non-nil value for Javascript buffers using `setq-local' macro."
   :group 'tide
   :safe #'booleanp)
 
-(defcustom tide-native-json-parsing (and (<= emacs-major-version 27)
+(defcustom tide-native-json-parsing (and (>= emacs-major-version 27)
                                          (functionp 'json-serialize)
                                          (functionp 'json-parse-buffer)
                                          (functionp 'json-parse-string))


### PR DESCRIPTION
I took a stab at making tide use the native json parser when it is available. There is a new variable `tide-native-json-parsing` that controls which JSON parser is used. I am quite new to writing elisp so I am happy to have feedback on how to improve the code.

Closes #374