### PR TITLE
Leave company-backends for the user to setup

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -125,6 +125,11 @@ errors and tide-project-errors buffer."
   :type 'boolean
   :group 'tide)
 
+(defcustom tide-completion-setup-company-backend t
+  "Add `company-tide' to `company-backends'."
+  :type 'boolean
+  :group 'tide)
+
 (defcustom tide-completion-ignore-case nil
   "CASE will be ignored in completion if set to non-nil."
   :type 'boolean
@@ -1650,7 +1655,8 @@ This function is used for the basic completions sorting."
     ((post-completion) (tide-post-completion arg))))
 
 (with-eval-after-load 'company
-  (cl-pushnew 'company-tide company-backends))
+  (when tide-completion-setup-company-backend
+    (cl-pushnew 'company-tide company-backends)))
 
 ;;; References
 


### PR DESCRIPTION
Loading `tide.el` has the side-effect of adding the completion backend to `company-backends` with no configuration option. The user may however not wish to use `company-tide`, or not have it as the first backend.

Other `company` packages do not mangle `company-backends`, instead documenting the code to add their backend, to allow the user to add the backends in their preferred order (examples: [1](https://github.com/krzysztof-magosa/company-ansible#how-to-configure-company), [2](https://github.com/randomphrase/company-c-headers/tree/5e676ab0c2f287c868b1e3931afd4c78895910cd#setup), [3](https://github.com/tigersoldier/company-lsp/tree/f921ffa0cdc542c21dc3dd85f2c93df4288e83bd#usage)). I therefore propose this change to follow this convention.