### PR TITLE
Improve file ignoring in tide-project-errors view

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -252,6 +252,11 @@ this variable to non-nil value for Javascript buffers using `setq-local' macro."
   :type 'boolean
   :group 'tide)
 
+(defcustom tide-project-files-ignore-patterns '("node_modules" "tsconfig.*.json$")
+  "List of regular expressions to ignore while displaying errors with `tide-project-errors'."
+  :type '(repeat string)
+  :group 'tide)
+
 (defconst tide--minimal-emacs
   "24.4"
   "This is the oldest version of Emacs that tide supports.")
@@ -2402,8 +2407,8 @@ current buffer."
       (erase-buffer))
     (display-buffer (current-buffer) t)
     (let* ((project-files (-reject (lambda (file-name)
-                                     (or (string-match-p "node_modules" file-name)
-                                         (string-match-p "tsconfig.json$" file-name)))
+                                     (cl-some (lambda (ignore-pat)
+                                                (string-match-p ignore-pat file-name)) tide-project-files-ignore-patterns))
                                    file-names))
            (syntax-remaining-files (cl-copy-list project-files))
            (semantic-remaining-files (cl-copy-list project-files))

--- a/tide.el
+++ b/tide.el
@@ -2427,7 +2427,12 @@ current buffer."
                  (file-name (tide-plist-get response :body :file))
                  (diagnostics (tide-plist-get response :body :diagnostics))
                  (event-type (plist-get response :event)))
-	     (unless (and (string-equal event-type "suggestionDiag") tide-disable-suggestions)
+       (unless (or
+                  (and (string-equal event-type "suggestionDiag") tide-disable-suggestions)
+                  (not (or
+                         (-contains? syntax-remaining-files file-name)
+                         (-contains? semantic-remaining-files file-name)
+                         (-contains? suggestion-remaining-files file-name))))
 	       (pcase event-type
 		 ("syntaxDiag"
 		  (setq syntax-remaining-files (remove file-name syntax-remaining-files))


### PR DESCRIPTION
This PR introduce new configuration option `tide-project-files-ignore-patterns` which allows for better control of what files are displayed in `tide-project-errors` buffer.

It also makes sure that the errors from filtered `project-files` are not displayed in the buffer - I had a problem where I was getting entries for files from my node_modules even thought they should be filtered out. I think that this should be fixed by https://github.com/ananthakumaran/tide/pull/315 , so maybe this was an unrelated error.