### PR TITLE
Adding tide-eledoc-display-message-p()

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -1219,17 +1219,20 @@ Noise can be anything like braces, reserved keywords, etc."
            (tide-eldoc-maybe-show (tide-doc-text (plist-get response :body))))))))
   nil)
 
+(defun tide-eledoc-display-message-p()
+  (if (fboundp #'eldoc-display-message-no-interference-p)
+      (eldoc-display-message-no-interference-p)
+    (eldoc-display-message-p)))
 
 ;;; Copied from eldoc.el
 (defun tide-eldoc-maybe-show (text)
   (with-demoted-errors "eldoc error: %s"
-    (and (or (eldoc-display-message-p)
+    (and (or (tide-eledoc-display-message-p)
              ;; Erase the last message if we won't display a new one.
              (when eldoc-last-message
                (eldoc-message nil)
                nil))
          (eldoc-message text))))
-
 
 (defun tide-documentation-at-point ()
   "Show documentation of the symbol at point."


### PR DESCRIPTION
In Emacs 28+, eldoc-display-message-p() has been refactored to
eldoc-display-message-no-interference-p().

tide-eledoc-display-message-p() uses eldoc-display-message-no-interference-p()
if available, and falls back to eldoc-display-message-p() if not.

See #390