### PR TITLE
Adding Yarn 2 PnP support

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -39,6 +39,7 @@
 (require 'thingatpt)
 (require 'tide-lv)
 (require 'tabulated-list)
+(require 'arc-mode)
 
 ;; Silence compiler warnings
 
@@ -408,20 +409,61 @@ ones and overrule settings in the other lists."
         (setq rtn (plist-put rtn p v))))
     rtn))
 
+(defun tide--get-arc-path-pair (full-path)
+  (let ((path-components (split-string full-path "/\\|\\\\"))
+        (arc-path "")
+        (file-path-in-arc "")
+        arc-found)
+    ;; Distinguishing absolute and relative paths - i.e. trailing "/".
+    (unless (string-empty-p (car path-components))
+      (setq arc-path (car path-components)))
+    (setq path-components (cdr path-components))
+    (seq-do
+     (lambda (component)
+       (if arc-found
+           (setq file-path-in-arc (concat file-path-in-arc "/" component))
+         (setq arc-path (concat arc-path "/" component))
+         (when (and (file-regular-p arc-path)
+                    (with-temp-buffer
+                      ;; 300000 is a magic number - it should
+                      ;; be more than enough to recognise any achieve
+                      ;; type header.
+                      (insert-file-contents arc-path nil 0 300000)
+                      (ignore-errors (archive-find-type))))
+           (setq arc-found t))))
+     path-components)
+    (and arc-found
+         (not (string-empty-p arc-path))
+         (not (string-empty-p file-path-in-arc))
+         (cons arc-path (substring file-path-in-arc 1)))))
+
 (defun tide-get-file-buffer (file &optional new-file)
   "Returns a buffer associated with a file. This will return the
 current buffer if it matches `file'. This way we can support
 temporary and indirect buffers."
-  (cond
-   ((equal file (tide-buffer-file-name)) (current-buffer))
-   ((file-exists-p file) (find-file-noselect file))
-   (new-file (let ((buffer (create-file-buffer file)))
-               (with-current-buffer buffer
-                 (set-visited-file-name file)
-                 (basic-save-buffer)
-                 (display-buffer buffer t))
-               buffer))
-   (t (error "Invalid file %S" file))))
+  (let (arc-path-pair)
+    (cond
+     ((equal file (tide-buffer-file-name)) (current-buffer))
+     ((setq arc-path-pair
+            (tide--get-arc-path-pair
+             (replace-regexp-in-string "\\$\\$virtual.*cache/" "cache/" file)))
+      (let ((arc-path (car arc-path-pair))
+            (file-path-in-arc (cdr arc-path-pair))
+            arc-buf)
+        (setq arc-buf (find-file-noselect arc-path))
+        (with-current-buffer arc-buf
+          (goto-char (point-min))
+          ;; This should fail in nested archives.
+          (search-forward file-path-in-arc)
+          (archive-extract))))
+     ((file-exists-p file) (find-file-noselect file))
+     (new-file (let ((buffer (create-file-buffer file)))
+                 (with-current-buffer buffer
+                   (set-visited-file-name file)
+                   (basic-save-buffer)
+                   (display-buffer buffer t))
+                 buffer))
+     (t (error "Invalid file %S" file)))))
 
 (defun tide-response-success-p (response)
   (and response (equal (plist-get response :success) t)))
@@ -1232,7 +1274,8 @@ Noise can be anything like braces, reserved keywords, etc."
              (when eldoc-last-message
                (eldoc-message nil)
                nil))
-         (eldoc-message text))))
+         (eldoc-message (replace-regexp-in-string
+                         "\\$\\$virtual.*\\(cache/\\)" "\\1" text)))))
 
 (defun tide-documentation-at-point ()
   "Show documentation of the symbol at point."


### PR DESCRIPTION
This patch allows tide to jump to files stored in zip packages (in Yarn 2 cache)
using Emacs arc-mode.

See #388

(This PR replaces closed PR #392)