### PR TITLE
fix code edit handling on tide-rename-file

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -2027,7 +2027,7 @@ number."
     (tide-cleanup-buffer)
     (mkdir (file-name-directory new) t)
     (rename-file old new)
-    (rename-buffer new)
+    (rename-buffer (file-name-nondirectory new))
     (set-visited-file-name new)
     (set-buffer-modified-p nil)
     (tide-apply-code-edits after-rename-edits)

--- a/tide.el
+++ b/tide.el
@@ -2019,6 +2019,20 @@ number."
 (defun tide-command:getEditsForFileRename (old new)
   (tide-send-command-sync "getEditsForFileRename" `(:oldFilePath ,old :newFilePath ,new :file ,old)))
 
+(defun tide-do-rename-file (old new edits)
+  (let* ((code-edit-for-old-p (lambda (code-edit) (string= (plist-get code-edit :fileName) old)))
+         (before-rename-edits (-select code-edit-for-old-p edits))
+         (after-rename-edits (-reject code-edit-for-old-p edits)))
+    (tide-apply-code-edits before-rename-edits)
+    (tide-cleanup-buffer)
+    (mkdir (file-name-directory new) t)
+    (rename-file old new)
+    (rename-buffer new)
+    (set-visited-file-name new)
+    (set-buffer-modified-p nil)
+    (tide-apply-code-edits after-rename-edits)
+    (revert-buffer t t t)))
+
 (defun tide-rename-file ()
   "Rename current file and all it's references in other files."
   (interactive)
@@ -2032,19 +2046,12 @@ number."
         (error "A buffer named '%s' already exists." new))
       (when (file-exists-p new)
         (error "A file named '%s' already exists." new))
-      (let* ((response (tide-command:getEditsForFileRename (expand-file-name old) (expand-file-name new)))
-             (edits (tide-on-response-success response (:min-version "2.9")
-                      (plist-get response :body))))
-        (tide-cleanup-buffer)
-        (mkdir (file-name-directory new) t)
-        (rename-file old new)
-        (rename-buffer new)
-        (set-visited-file-name new)
-        (set-buffer-modified-p nil)
-        (when edits
-          (tide-apply-code-edits edits))
-        (tide-configure-buffer)
-        (message "Renamed '%s' to '%s'." name (file-name-nondirectory new))))))
+      (let* ((old (expand-file-name old))
+             (new (expand-file-name new))
+             (response (tide-command:getEditsForFileRename old new)))
+        (tide-on-response-success response (:min-version "2.9")
+          (tide-do-rename-file old new (plist-get response :body))
+          (message "Renamed '%s' to '%s'." name (file-name-nondirectory new)))))))
 
 ;;; Format
 


### PR DESCRIPTION
tsserver used to? send code edits for the new file name. Looks like it
sends code edits for old file name now. If we get any edits for old
file, apply it before rename. Apply the rest of the code edits after rename.

fixes #406 