### PR TITLE
Fix tide-rename-file bug on new buffer name;

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -2027,7 +2027,7 @@ number."
     (tide-cleanup-buffer)
     (mkdir (file-name-directory new) t)
     (rename-file old new)
-    (rename-buffer (file-name-nondirectory new))
+    (rename-buffer (file-name-nondirectory new) t)
     (set-visited-file-name new)
     (set-buffer-modified-p nil)
     (tide-apply-code-edits after-rename-edits)


### PR DESCRIPTION
fixes #408:
If the new name of a buffer clashes with an opened buffer then
tide-rename-file stops and doesn't apply after-rename-edits.
Especially problematic because tide leaves buffers open as it applies
code edits.