### PR TITLE
Make no-server errors less naggy

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -653,19 +653,25 @@ Offset is one based."
     ((event) (tide-dispatch-event response))))
 
 (defun tide-send-command (name args &optional callback)
-  (unless (tide-current-server)
-    (error "Server does not exist. Run M-x tide-restart-server to start it again"))
+  (if (not (tide-current-server))
+    (let* ((message "Server does not exist, run M-x tide-restart-server to start it again")
+           (already-barfed
+            (with-current-buffer (messages-buffer)
+              (save-excursion (goto-char (point-max))
+                              (forward-line -1)
+                              (save-match-data (re-search-forward message nil t))))))
+      (unless already-barfed (error "%s" message)))
 
-  (tide-sync-buffer-contents)
+    (tide-sync-buffer-contents)
 
-  (let* ((request-id (tide-next-request-id))
-         (command `(:command ,name :seq ,request-id :arguments ,args))
-         (json-encoding-pretty-print nil)
-         (encoded-command (tide-json-encode command))
-         (payload (concat encoded-command "\n")))
-    (process-send-string (tide-current-server) payload)
-    (when callback
-      (puthash request-id (cons (current-buffer) callback) tide-response-callbacks))))
+    (let* ((request-id (tide-next-request-id))
+           (command `(:command ,name :seq ,request-id :arguments ,args))
+           (json-encoding-pretty-print nil)
+           (encoded-command (tide-json-encode command))
+           (payload (concat encoded-command "\n")))
+      (process-send-string (tide-current-server) payload)
+      (when callback
+        (puthash request-id (cons (current-buffer) callback) tide-response-callbacks)))))
 
 (defun tide-send-command-sync (name args)
   (let* ((start-time (current-time))
@@ -774,7 +780,7 @@ in the npm global installation.  If nothing is found use the bundled version."
 
 (defun tide-start-server ()
   (when (tide-current-server)
-    (error "Server already exist"))
+    (error "Server already exists"))
 
   (message "(%s) Starting tsserver..." (tide-project-name))
   (let* ((default-directory (tide-project-root))


### PR DESCRIPTION
Every once in a while I run into a situation where the server is either
dead or just misbehaving for whatever reason.  Since tide tends to send
a lot of messages to the server, this leads to an annoying state where
it keeps barfing over and over again.

This avoids throwing the no server error if it was just thrown.

---

I think that there are other situations where things get overly
annoying: I think that there are either other similar errors, and/or
other situations that lead to excessive nagging.  If so, then more
work will be needed, but I wanted to put it out now to see if
there's any opinions about doing this.
