### PR TITLE
Avoid triggering too many change hooks

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -1258,7 +1258,7 @@ Noise can be anything like braces, reserved keywords, etc."
   nil)
 
 (defun tide-eldoc-display-message-p()
-  (if (fboundp #'eldoc-display-message-no-interference-p)
+  (if (fboundp 'eldoc-display-message-no-interference-p)
       (eldoc-display-message-no-interference-p)
     (eldoc-display-message-p)))
 
@@ -2172,10 +2172,16 @@ code-analysis."
     (tide-insert (plist-get edit :newText))
     (cons start (point-marker))))
 
-(defun tide-apply-edits (edits)
+(defun tide-do-apply-edits (edits)
   (save-excursion
     (-map (lambda (edit) (tide-apply-edit edit))
           (nreverse edits))))
+
+(defun tide-apply-edits (edits)
+  (if (and (fboundp 'combine-change-calls)
+           (> (length edits) 2))
+      (combine-change-calls (point-min) (point-max) (tide-do-apply-edits edits))
+    (tide-do-apply-edits edits)))
 
 (defun tide-format-region (start end)
   (let ((response (tide-send-command-sync


### PR DESCRIPTION
This commit attempts to reduce the number of times
`after-change-functions` is called when edits are applied. Otherwise,
with large enough buffer and complex font locking rules, emacs could
get blocked for long time.

Ideally the start and end of the region that is being changed should
be supplied to the function, but I am not sure how it could be
calculated easily as each edit affects successive edits' region.

For now, I have settled on using the min max point of the buffer and
apply the optimization only if there are more than two edits.

see #427