### PR TITLE
Fix handling of timestamps in new `(TICKS . HZ)` format

### DIFF
--- a/tide-tests.el
+++ b/tide-tests.el
@@ -125,7 +125,7 @@
 (ert-deftest seconds-elapsed-gets-calculated ()
   (let ((start-time (current-time)))
     (sleep-for 5)
-    (let ((elapsed (seconds-elapsed-since start-time)))
+    (let ((elapsed (tide-seconds-elapsed-since start-time)))
       (should (and (> elapsed 5) (< elapsed 5.1))))))
 
 ;; Adapted from jdee-mode's test suite.

--- a/tide-tests.el
+++ b/tide-tests.el
@@ -122,6 +122,12 @@
   (should (tide-plist-equal '(:a 1 :b (:nest 1 :nest2 2)) '(:a 1 :b (:nest2 2 :nest 1))))
   (should-not (tide-plist-equal '(:a 1 :b (:nest 1)) '(:a 1 :b (:nest 2)))))
 
+(ert-deftest seconds-elapsed-gets-calculated ()
+  (let ((start-time (current-time)))
+    (sleep-for 5)
+    (let ((elapsed (seconds-elapsed-since start-time)))
+      (should (and (> elapsed 5) (< elapsed 5.1))))))
+
 ;; Adapted from jdee-mode's test suite.
 (defmacro mode-with-temp-buffer (content &rest body)
   "Fill a temporary buffer with `CONTENT', turn on `tide-mode' and eval `BODY' in it."

--- a/tide.el
+++ b/tide.el
@@ -672,7 +672,7 @@ Offset is one based."
     (when callback
       (puthash request-id (cons (current-buffer) callback) tide-response-callbacks))))
 
-(defun seconds-elapsed-since (time)
+(defun tide-seconds-elapsed-since (time)
   (time-to-seconds (time-subtract (current-time) time)))
 
 (defun tide-send-command-sync (name args)
@@ -681,7 +681,7 @@ Offset is one based."
     (tide-send-command name args (lambda (resp) (setq response resp)))
     (while (not response)
       (accept-process-output nil 0.01)
-      (when (> (seconds-elapsed-since start-time) tide-sync-request-timeout)
+      (when (> (tide-seconds-elapsed-since start-time) tide-sync-request-timeout)
         (error "Sync request timed out %s" name)))
     response))
 

--- a/tide.el
+++ b/tide.el
@@ -672,14 +672,16 @@ Offset is one based."
     (when callback
       (puthash request-id (cons (current-buffer) callback) tide-response-callbacks))))
 
+(defun seconds-elapsed-since (time)
+  (time-to-seconds (time-subtract (current-time) time)))
+
 (defun tide-send-command-sync (name args)
   (let* ((start-time (current-time))
          (response nil))
     (tide-send-command name args (lambda (resp) (setq response resp)))
     (while (not response)
       (accept-process-output nil 0.01)
-      (when (> (time-to-seconds (time-subtract (current-time) start-time))
-               tide-sync-request-timeout)
+      (when (> (seconds-elapsed-since start-time) tide-sync-request-timeout)
         (error "Sync request timed out %s" name)))
     response))
 

--- a/tide.el
+++ b/tide.el
@@ -678,7 +678,7 @@ Offset is one based."
     (tide-send-command name args (lambda (resp) (setq response resp)))
     (while (not response)
       (accept-process-output nil 0.01)
-      (when (> (cadr (time-subtract (current-time) start-time))
+      (when (> (time-to-seconds (time-subtract (current-time) start-time))
                tide-sync-request-timeout)
         (error "Sync request timed out %s" name)))
     response))


### PR DESCRIPTION
Emacs is rolling out a new timestamp format, to be used by time-handling functions such as `current-time` and `time-subtract`. Tide assumes timestamps are in the old `(HI LO US PS)` format, and attempts to extract a number of seconds by directly pulling out an element from this list with `cadr`.  In order to properly work with the changing timestamp format, we need to use Emacs' provided functions for handling timestamps, rather than poking at the internals directly.