### PR TITLE
Treesitter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@
 ;; formats the buffer before saving
 (add-hook 'before-save-hook 'tide-format-before-save)
 
+;; if you use typescript-mode
 (add-hook 'typescript-mode-hook #'setup-tide-mode)
+;; if you use treesitter based typescript-ts-mode (emacs 29+)
+(add-hook 'typescript-ts-mode-hook #'setup-tide-mode)
 ```
 
 #### Format options
@@ -66,7 +69,7 @@ Format options can be specified in multiple ways.
 Check [here][format_options] for the full list of supported format options.
 
 
-#### TSX
+#### TSX without treesitter
 ```elisp
 (require 'web-mode)
 (add-to-list 'auto-mode-alist '("\\.tsx\\'" . web-mode))
@@ -76,6 +79,11 @@ Check [here][format_options] for the full list of supported format options.
               (setup-tide-mode))))
 ;; enable typescript-tslint checker
 (flycheck-add-mode 'typescript-tslint 'web-mode)
+```
+#### TSX with treesitter
+Treesitter comes with tsx major mode built in.
+```elisp
+(add-hook 'tsx-ts-mode-hook #'setup-tide-mode)
 ```
 
 Tide also provides support for editing js & jsx files. Tide checkers
@@ -123,11 +131,21 @@ true.
 
 #### Use Package
 ```elisp
+;; if you use typescript-mode
 (use-package tide
   :ensure t
   :after (typescript-mode company flycheck)
   :hook ((typescript-mode . tide-setup)
          (typescript-mode . tide-hl-identifier-mode)
+         (before-save . tide-format-before-save)))
+         
+;; if you use treesitter based typescript-ts-mode (emacs 29+)
+(use-package tide
+  :ensure t
+  :after (company flycheck)
+  :hook ((typescript-ts-mode . tide-setup)
+         (tsx-ts-mode . tide-setup)
+         (typescript-ts-mode . tide-hl-identifier-mode)
          (before-save . tide-format-before-save)))
 ```
 

--- a/tide-tests.el
+++ b/tide-tests.el
@@ -14,8 +14,7 @@
 (package-initialize)
 (add-to-list 'package-archives '("melpa" . "https://stable.melpa.org/packages/"))
 
-;; tide depends on typescript-mode
-(dolist (p '(dash s flycheck typescript-mode))
+(dolist (p '(dash s flycheck))
   (when (not (package-installed-p p))
     (package-refresh-contents)
     (package-install p)))

--- a/tide.el
+++ b/tide.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/ananthakumaran/tide
 ;; Version: 4.5.4
 ;; Keywords: typescript
-;; Package-Requires: ((emacs "25.1") (dash "2.10.0") (s "1.11.0") (flycheck "27") (typescript-mode "0.1") (cl-lib "0.5"))
+;; Package-Requires: ((emacs "25.1") (dash "2.10.0") (s "1.11.0") (flycheck "27") (cl-lib "0.5"))
 
 ;; This program is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by
@@ -27,7 +27,6 @@
 
 ;;; Code:
 
-(require 'typescript-mode)
 (require 'etags)
 (require 'json)
 (require 'cl-lib)
@@ -1511,7 +1510,7 @@ always be formatted as described above."
           (open-line 1))
         (insert "// tslint:disable-next-line:"
                 (string-join error-ids " "))
-        (typescript-indent-line)))))
+        (indent-according-to-mode)))))
 
 ;;; Disable Eslint Warnings
 
@@ -1553,7 +1552,7 @@ always be formatted as described above."
           (open-line 1))
         (insert "// eslint-disable-next-line "
                 (string-join error-ids ", "))
-        (typescript-indent-line)))))
+        (indent-according-to-mode)))))
 
 ;;; Auto completion
 
@@ -2346,9 +2345,7 @@ current buffer."
         (add-hook 'hack-local-variables-hook
                   'tide-configure-buffer-if-server-exists nil t)
         (when tide-enable-xref
-          (add-hook 'xref-backend-functions #'xref-tide-xref-backend nil t))
-        (when (commandp 'typescript-insert-and-indent)
-          (eldoc-add-command 'typescript-insert-and-indent)))
+          (add-hook 'xref-backend-functions #'xref-tide-xref-backend nil t)))
     (remove-hook 'after-save-hook 'tide-sync-buffer-contents t)
     (remove-hook 'after-save-hook 'tide-auto-compile-file t)
     (remove-hook 'after-change-functions 'tide-handle-change t)

--- a/tide.el
+++ b/tide.el
@@ -300,7 +300,7 @@ this variable to non-nil value for Javascript buffers using `setq-local' macro."
      (make-variable-buffer-local ',name)
      (put ',name 'permanent-local t)))
 
-(defvar tide-supported-modes '(typescript-mode web-mode js-mode js2-mode js2-jsx-mode js3-mode rjsx-mode))
+(defvar tide-supported-modes '(typescript-mode typescript-ts-base-mode web-mode js-mode js2-mode js2-jsx-mode js3-mode rjsx-mode))
 
 (defvar tide-server-buffer-name "*tide-server*")
 (defvar tide-request-counter 0)
@@ -2505,7 +2505,7 @@ current buffer."
   "A TypeScript syntax checker using tsserver."
   :start #'tide-flycheck-start
   :verify #'tide-flycheck-verify
-  :modes '(typescript-mode)
+  :modes '(typescript-mode typescript-ts-base-mode)
   :predicate #'tide-flycheck-predicate)
 
 (add-to-list 'flycheck-checkers 'typescript-tide)
@@ -2535,7 +2535,7 @@ current buffer."
   "A TSX syntax checker using tsserver."
   :start #'tide-flycheck-start
   :verify #'tide-flycheck-verify
-  :modes '(web-mode)
+  :modes '(web-mode typescript-ts-base-mode)
   :predicate (lambda ()
                (and
                 (tide-file-extension-p "tsx")


### PR DESCRIPTION
This PR removes hard dependency on `typescript-mode` and adds support to treesitter based `typescript-ts-mode` (it keeps support for `typescript-mode`)

`typescript-mode` has been used directly only for indentation and after changing calls from `typescript-indent-line` to `indent-according-to-mode` we can safely remove hard dependency and support treesitter based modes at the same time.

