### PR TITLE
Update to eldoc 1.1.0 with support for emacs < 28.1

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -1262,16 +1262,19 @@ Noise can be anything like braces, reserved keywords, etc."
 (defun tide-command:quickinfo (cb)
   (tide-fallback-if-not-supported "quickinfo-full" tide-command:quickinfo-full tide-command:quickinfo-old cb))
 
-
 (defun tide-eldoc-function (&optional cb)
-  (unless (member last-command '(next-error previous-error))
-    (if (tide-method-call-p)
-        (tide-command:signatureHelp (lambda (text) (funcall #'tide-eldoc-maybe-show text cb)))
-      (when (looking-at "\\s_\\|\\sw")
-        (tide-command:quickinfo
-         (tide-on-response-success-callback response (:ignore-empty t)
-           (tide-eldoc-maybe-show (tide-doc-text (plist-get response :body)) cb))))))
-  nil)
+  (cond ((member last-command '(next-error previous-error))
+         nil)
+        ((tide-method-call-p)
+         (tide-command:signatureHelp (lambda (text) (tide-eldoc-maybe-show text cb)))
+         t)
+        ((looking-at "\\s_\\|\\sw")
+         (tide-command:quickinfo
+          (tide-on-response-success-callback response (:ignore-empty t)
+            (tide-eldoc-maybe-show (tide-doc-text (plist-get response :body)) cb)))
+         t)
+        (t
+         nil)))
 
 (defun tide-eldoc-display-message-p()
   (if (fboundp 'eldoc-display-message-no-interference-p)


### PR DESCRIPTION
This PR is a continuation of work done in https://github.com/ananthakumaran/tide/pull/456 

It checks if emacs version is less than 28.1 (where `eldoc` 1.1 got introduced) and uses the old mechanism in that case.