### PR TITLE
Enable flycheck checker on .js and .ts files

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -2545,7 +2545,7 @@ current buffer."
   :modes '(web-mode js2-jsx-mode rjsx-mode)
   :predicate (lambda ()
                (and
-                (tide-file-extension-p "jsx")
+                (or (tide-file-extension-p "jsx") (tide-file-extension-p "js"))
                 (tide-flycheck-predicate))))
 
 (add-to-list 'flycheck-checkers 'jsx-tide t)
@@ -2557,7 +2557,7 @@ current buffer."
   :modes '(web-mode tsx-ts-mode)
   :predicate (lambda ()
                (and
-                (tide-file-extension-p "tsx")
+                (or (tide-file-extension-p "tsx") (tide-file-extension-p "ts"))
                 (tide-flycheck-predicate))))
 
 (add-to-list 'flycheck-checkers 'tsx-tide)


### PR DESCRIPTION
The flycheck checker runs only on `.tsx` and `.jsx` files, but not all typescript files end with that extension. Files in the project without react components(HTML markup) in that end with plain `.ts` (eg. utility helpers, hooks) also need to be checked.