### PR TITLE
Include data in completionEntryDetails request

### DIFF
--- a/tide.el
+++ b/tide.el
@@ -1739,7 +1739,7 @@ This function is used for the basic completions sorting."
                              `(:entryNames [(:name ,name :source ,source :data ,data)]))
                             (source
                              `(:entryNames [(:name ,name :source ,source)]))
-                            (t `(:entryNames (,name)))))
+                            (t `(:entryNames [,name]))))
          (arguments (-concat (get-text-property 0 'file-location name)
                              entry-names)))
     (-when-let (response (tide-send-command-sync "completionEntryDetails" arguments))

--- a/tide.el
+++ b/tide.el
@@ -1739,6 +1739,8 @@ This function is used for the basic completions sorting."
                              `(:entryNames [(:name ,name :source ,source :data ,data)]))
                             (source
                              `(:entryNames [(:name ,name :source ,source)]))
+                            (data
+                             `(:entryNames [(:name ,name :data ,data)]))
                             (t `(:entryNames [,name]))))
          (arguments (-concat (get-text-property 0 'file-location name)
                              entry-names)))

--- a/tide.el
+++ b/tide.el
@@ -1734,9 +1734,12 @@ This function is used for the basic completions sorting."
 
 (defun tide-command:completionEntryDetails (name)
   (let* ((source (plist-get (get-text-property 0 'completion name) :source))
-         (entry-names (if source
-                          `(:entryNames [(:name ,name :source ,source)])
-                        `(:entryNames [,name])))
+         (data (plist-get (get-text-property 0 'completion name) :data))
+         (entry-names (cond ((and source data)
+                             `(:entryNames [(:name ,name :source ,source :data ,data)]))
+                            (source
+                             `(:entryNames [(:name ,name :source ,source)]))
+                            (t `(:entryNames (,name)))))
          (arguments (-concat (get-text-property 0 'file-location name)
                              entry-names)))
     (-when-let (response (tide-send-command-sync "completionEntryDetails" arguments))


### PR DESCRIPTION
At work some changes were made recently to the way module resolution works which broke auto importing in Tide. Other editors such as VSCode were not affected, so we compared the tsserver requests/responses between VSCode and Tide and noticed that `completionEntryDetails` was returning an empty body for Tide but not VSCode. The only difference between the two requests was that VSCode included the `data` property under `entryNames` (included in the response from the `completions` request), whereas Tide did not. Patching Tide to include `data` fixed the issue.

I'm not sure why after these tsconfig changes tsserver no longer can provide completion entry details without the extra data, but the change to support this is minimal so I thought I'd contribute it upstream in case others hit the same issue.